### PR TITLE
Move checkpoint callback to callbacks trainer argument

### DIFF
--- a/tests/test_runner_lightning_task.py
+++ b/tests/test_runner_lightning_task.py
@@ -44,7 +44,7 @@ class TestLightningTask(unittest.TestCase):
                 "max_steps": 1,
                 "limit_train_batches": 1,
                 "num_sanity_val_steps": 0,
-                "checkpoint_callback": checkpoint_callback,
+                "callbacks": [checkpoint_callback],
             }
             trainer = pl.Trainer(**params)
             with EventStorage() as storage:


### PR DESCRIPTION
Summary:
`checkpoint_callback` is being phased out. Initially, it was a special way to configure checkpoints, but it makes more sense for those callbacks to be included in the general `callbacks` trainer argument. In 1.2.X, `checkpoint_callback` is expected to be a boolean value only.

If `checkpoint_callback=False` **and** an instance of `ModelCheckpoint` is passed in the trainer's `callbacks` arguments, Lightning raises a [misconfiguration error](https://github.com/PyTorchLightning/pytorch-lightning/blob/2f6ce1ae7fff34d16d3707571f6a9a7b0fb0c50a/pytorch_lightning/trainer/connectors/callback_connector.py#L66-L70)

Reviewed By: newstzpz

Differential Revision: D27139315

