### PR TITLE
updated test utils import in d2go_beginner.ipynb

### DIFF
--- a/demo/d2go_beginner.ipynb
+++ b/demo/d2go_beginner.ipynb
@@ -580,7 +580,7 @@
     "import copy\n",
     "from detectron2.data import build_detection_test_loader\n",
     "from d2go.export.api import convert_and_export_predictor\n",
-    "from d2go.tests.data_loader_helper import create_fake_detection_data_loader\n",
+    "from d2go.utils.testing.data_loader_helper import create_fake_detection_data_loader\n",
     "from d2go.export.d2_meta_arch import patch_d2_meta_arch\n",
     "\n",
     "import logging\n",


### PR DESCRIPTION
In 9d23834, the test utils were moved to the core library, but the import for the create_fake_detection_data_loader inside the d2go_beginner.ipynb wasn't updated.