### PR TITLE
Remove methods_to_optimize from script

### DIFF
--- a/d2go/export/torchscript.py
+++ b/d2go/export/torchscript.py
@@ -24,7 +24,6 @@ class MobileOptimizationConfig(NamedTuple):
     optimization_blocklist: Set[MobileOptimizerType] = None
     preserved_methods: List[AnyStr] = None
     backend: str = "CPU"
-    methods_to_optimize: List[AnyStr] = None
 
 
 def trace_and_save_torchscript(
@@ -68,7 +67,6 @@ def trace_and_save_torchscript(
                 optimization_blocklist=mobile_optimization.optimization_blocklist,
                 preserved_methods=mobile_optimization.preserved_methods,
                 backend=mobile_optimization.backend,
-                methods_to_optimize=mobile_optimization.methods_to_optimize,
             )
             with _synced_local_file("mobile_optimized.ptl") as lite_path:
                 liteopt_model._save_for_lite_interpreter(lite_path)


### PR DESCRIPTION
Summary: This arg is being deprecated. Since this script was just created I'm hoping I can edit this without throwing lots of stuff out of wack.

Differential Revision: D27954176

