### PR TITLE
Upgrade python version for unittest on github

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: s-weigand/setup-conda@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
Error running unittest on github due to the following error
```
from typing import final
ImportError: cannot import name 'final' from 'typing' (/usr/share/miniconda/lib/python3.7/typing.py)
```