### PR TITLE
update runner in d2go_beginner script

### DIFF
--- a/demo/d2go_beginner.ipynb
+++ b/demo/d2go_beginner.ipynb
@@ -421,11 +421,11 @@
     }
    ],
    "source": [
-    "from d2go.runner import Detectron2GoRunner\n",
+    "from d2go.runner import GeneralizedRCNNRunner\n",
     "\n",
     "\n",
     "def prepare_for_launch():\n",
-    "    runner = Detectron2GoRunner()\n",
+    "    runner = GeneralizedRCNNRunner()\n",
     "    cfg = runner.get_default_cfg()\n",
     "    cfg.merge_from_file(model_zoo.get_config_file(\"faster_rcnn_fbnetv3a_C4.yaml\"))\n",
     "    cfg.MODEL_EMA.ENABLED = False\n",


### PR DESCRIPTION
Summary: Detectron2GoRunner doesn't contain configs about exporting RCNN models, use GeneralizedRCNNRunner instead

Differential Revision: D28652627

