### PR TITLE
remove hard-coded CfgNode

### DIFF
--- a/d2go/data/config.py
+++ b/d2go/data/config.py
@@ -2,10 +2,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-from d2go.config import CfgNode as CN
-
-
 def add_d2go_data_default_configs(_C):
+    CN = type(_C)
     _C.D2GO_DATA = CN()
 
     # Config for "detectron2go.data.extended_coco.extended_coco_load"

--- a/d2go/modeling/backbone/fbnet_cfg.py
+++ b/d2go/modeling/backbone/fbnet_cfg.py
@@ -2,13 +2,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-from d2go.config import CfgNode as CN
-
-
 def add_fbnet_default_configs(_C):
     """ FBNet options and default values
     """
-    _C.MODEL.FBNET = CN()
+    _C.MODEL.FBNET = type(_C)()
     _C.MODEL.FBNET.ARCH = "default"
     # custom arch
     _C.MODEL.FBNET.ARCH_DEF = ""
@@ -47,7 +44,7 @@ def add_fbnet_default_configs(_C):
 
 
 def add_fbnet_v2_default_configs(_C):
-    _C.MODEL.FBNET_V2 = CN()
+    _C.MODEL.FBNET_V2 = type(_C)()
 
     _C.MODEL.FBNET_V2.ARCH = "default"
     _C.MODEL.FBNET_V2.ARCH_DEF = []
@@ -67,7 +64,7 @@ def add_fbnet_v2_default_configs(_C):
     # https://github.com/rbgirshick/yacs/blob/master/yacs/config.py#L410
     _C.MODEL.FBNET_V2.NORM_ARGS = []
 
-    _C.MODEL.VT_FPN = CN()
+    _C.MODEL.VT_FPN = type(_C)()
 
     _C.MODEL.VT_FPN.IN_FEATURES = ["res2", "res3", "res4", "res5"]
     _C.MODEL.VT_FPN.OUT_CHANNELS = 256
@@ -82,7 +79,7 @@ def add_fbnet_v2_default_configs(_C):
 
 
 def add_bifpn_default_configs(_C):
-    _C.MODEL.BIFPN = CN()
+    _C.MODEL.BIFPN = type(_C)()
 
     _C.MODEL.BIFPN.DEPTH_MULTIPLIER = 1
     _C.MODEL.BIFPN.SCALE_FACTOR = 1

--- a/d2go/modeling/kmeans_anchors.py
+++ b/d2go/modeling/kmeans_anchors.py
@@ -18,13 +18,13 @@ from detectron2.modeling.anchor_generator import (
 )
 from detectron2.modeling.proposal_generator.rpn import RPN
 from detectron2.structures.boxes import Boxes
-from d2go.config import temp_defrost, CfgNode as CN
+from d2go.config import temp_defrost
 
 logger = logging.getLogger(__name__)
 
 
 def add_kmeans_anchors_cfg(_C):
-    _C.MODEL.KMEANS_ANCHORS = CN()
+    _C.MODEL.KMEANS_ANCHORS = type(_C)()
     _C.MODEL.KMEANS_ANCHORS.KMEANS_ANCHORS_ON = False
     _C.MODEL.KMEANS_ANCHORS.NUM_CLUSTERS = 0
     _C.MODEL.KMEANS_ANCHORS.NUM_TRAINING_IMG = 0

--- a/d2go/modeling/subclass.py
+++ b/d2go/modeling/subclass.py
@@ -13,7 +13,6 @@ from torch.nn import functional as F
 from detectron2.layers import cat
 from detectron2.modeling import ROI_HEADS_REGISTRY, StandardROIHeads
 from detectron2.utils.registry import Registry
-from d2go.config import CfgNode as CN
 from d2go.data.dataset_mappers import (
     D2GO_DATA_MAPPER_REGISTRY,
     D2GoDatasetMapper,
@@ -27,7 +26,7 @@ SUBCLASS_FETCHER_REGISTRY = Registry("SUBCLASS_FETCHER")
 
 def add_subclass_configs(cfg):
     _C = cfg
-    _C.MODEL.SUBCLASS = CN()
+    _C.MODEL.SUBCLASS = type(_C)()
     _C.MODEL.SUBCLASS.SUBCLASS_ON = False
     _C.MODEL.SUBCLASS.NUM_SUBCLASSES = 0  # must be set
     _C.MODEL.SUBCLASS.NUM_LAYERS = 1

--- a/d2go/utils/get_default_cfg.py
+++ b/d2go/utils/get_default_cfg.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from d2go.config import CfgNode as CN
 from d2go.data.build import (
     add_weighted_training_sampler_default_configs,
 )
@@ -16,7 +15,7 @@ from d2go.modeling.subclass import add_subclass_configs
 
 
 def add_tensorboard_default_configs(_C):
-    _C.TENSORBOARD = CN()
+    _C.TENSORBOARD = type(_C)()
     # Output from dataloader will be written to tensorboard at this frequency
     _C.TENSORBOARD.TRAIN_LOADER_VIS_WRITE_PERIOD = 20
     # This controls max number of images over all batches, be considerate when
@@ -30,7 +29,7 @@ def add_tensorboard_default_configs(_C):
 
 
 def add_abnormal_checker_configs(_C):
-    _C.ABNORMAL_CHECKER = CN()
+    _C.ABNORMAL_CHECKER = type(_C)()
     # check and log the iteration with bad losses if enabled
     _C.ABNORMAL_CHECKER.ENABLED = False
 


### PR DESCRIPTION
Summary:
Currently, `CfgNode` is hard-coded to be the one from D2 (https://github.com/facebookresearch/d2go/commit/73f0f05f67e93359f64122ad5f39db5a68dcb302)GO. This prevents downstream modules using customized CfgNode without compatibility issue.

This diff fixes it by inferring the type of CfgNode on the fly.

Differential Revision: D28800227

