### PR TITLE
fix model_zoo links & retrain V3G mask rcnn

### DIFF
--- a/MODEL_ZOO.md
+++ b/MODEL_ZOO.md
@@ -49,7 +49,7 @@ FBNet series are efficient mobile backbones discovered via neural architecture s
 | ------------------------------------------------------------ | ------ | ------- | --------- | ------------------------------------------------------------ |
 | [Mask-RCNN-FBNetV3A](./configs/mask_rcnn_fbnetv3a_C4.yaml)   | 23.05  | 20.71   | 268421013 | [model](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/268421013/model_final.pth) \|[metrics](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/268421013/metrics.json) |
 | [Mask-RCNN-FBNetV3A-dsmask](./configs/mask_rcnn_fbnetv3a_dsmask_C4.yaml) | 21.76  | 19.97   | 268412271 | [model](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/268412271/model_0499999.pth) \|[metrics](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/268412271/metrics.json) |
-| [Mask-RCNN-FBNetV3G-FPN](./configs/mask_rcnn_fbnetv3g_fpn.yaml) | 43.88  | 39.25   | 250376154 | [model](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/250376154/model_0404999.pth) \|[metrics](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/250376154/metrics.json) |
+| [Mask-RCNN-FBNetV3G-FPN](./configs/mask_rcnn_fbnetv3g_fpn.yaml) | 43.31  | 39.24   | 287445123 | [model](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/287445123/model_0409999.pth) \|[metrics](https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/287445123/metrics.json) |
 
 ### COCO Person Keypoint Detection
 

--- a/configs/mask_rcnn_fbnetv3g_fpn.yaml
+++ b/configs/mask_rcnn_fbnetv3g_fpn.yaml
@@ -35,8 +35,7 @@ MODEL:
     POOLER_RESOLUTION: 6
     NORM: "naiveSyncBN"
   ROI_MASK_HEAD:
-    NAME: "MaskRCNNConvUpsampleHead"
-    NUM_CONV: 4
+    NAME: "FBNetV2RoIMaskHead"
     POOLER_RESOLUTION: 14
     NORM: "naiveSyncBN"
 MODEL_EMA:

--- a/d2go/model_zoo/model_zoo.py
+++ b/d2go/model_zoo/model_zoo.py
@@ -13,12 +13,12 @@ class _ModelZooUrls(object):
     """
     S3_PREFIX = "https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/"
     CONFIG_PATH_TO_URL_SUFFIX = {
-        "faster_rcnn_fbnetv3a_C4.yaml": "246823121/model_0479999.pth",
-        "faster_rcnn_fbnetv3a_dsmask_C4.yaml": "250414811/model_0399999.pth",
+        "faster_rcnn_fbnetv3a_C4.yaml": "268421013/model_final.pth",
+        "faster_rcnn_fbnetv3a_dsmask_C4.yaml": "268412271/model_0499999.pth",
         "faster_rcnn_fbnetv3g_fpn.yaml": "250356938/model_0374999.pth",
         "mask_rcnn_fbnetv3a_C4.yaml": "250355374/model_0479999.pth",
         "mask_rcnn_fbnetv3a_dsmask_C4.yaml": "250414867/model_0399999.pth",
-        "mask_rcnn_fbnetv3g_fpn.yaml": "250376154/model_0404999.pth",
+        "mask_rcnn_fbnetv3g_fpn.yaml": "287445123/model_0409999.pth",
         "keypoint_rcnn_fbnetv3a_dsmask_C4.yaml": "250430934/model_0389999.pth",
     }
 


### PR DESCRIPTION
Summary:
- fix model_zoo model urls (missed in D27992340 (https://github.com/facebookresearch/d2go/commit/477ab964e2165cb586b5c00425f6e463d7edeadd))
- update mask rcnn fbnet V3G config
- TODO: update v3g retrained weights

Differential Revision: D29627615

