### PR TITLE
support scripting for torchscript ExportMethod

### DIFF
--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -80,12 +80,17 @@ def default_rcnn_prepare_for_export(self, cfg, inputs, predictor_type):
         )
 
         preprocess_func = preprocess_info.instantiate()
+        model_export_kwargs = {}
+        if "torchscript" in predictor_type:
+            model_export_kwargs["force_disable_tracing_adapter"] = True
 
         return PredictorExportConfig(
             model=c2_compatible_model,
             # Caffe2MetaArch takes a single tuple as input (which is the return of
             # preprocess_func), data_generator requires all positional args as a tuple.
             data_generator=lambda x: (preprocess_func(x),),
+            model_export_method=predictor_type.replace("@legacy", "", 1),
+            model_export_kwargs=model_export_kwargs,
             preprocess_info=preprocess_info,
             postprocess_info=postprocess_info,
         )

--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -369,7 +369,7 @@ class D2RCNNInferenceWrapper(nn.Module):
     def forward(self, image):
         """
         This function describes what happends during the tracing. Note that the output
-        contains non-tensor, therefore the D2TorchscriptTracingExport must be used in
+        contains non-tensor, therefore the TracingAdaptedTorchscriptExport must be used in
         order to convert the output back from flattened tensors.
         """
         inputs = [{"image": image}]


### PR DESCRIPTION
Summary:
This diff adds the proper support for using scripting when exporting model.
- Previously `trace_and_save_torchscript` is the primary function to export model, replace it with `export_optimize_and_save_torchscript`.
- Add `jit_mode` option as the `export_kwargs` of ExportMethod.
- Add `scripting` and `tracing` trigger words to overwrite `jit_mode`. Please not that the `tracing` now applies to all models, which is different from using `TracingAdapter` for RCNN.
- Therefore there're two ways of using scripting mode, 1) setting `jit_mode` in prepare_for_export; 2) using `script` trigger words
- Add unit test.

Differential Revision: D31181624

