### PR TITLE
add num_threads metadata, change metadata format to dict

### DIFF
--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -172,6 +172,8 @@ def prepare_for_launch(args):
         cfg.merge_from_list(args.opts)
     else:
         cfg = create_cfg_from_cli_args(args, default_cfg=cfg)
+    if args.num_threads is not None:
+        cfg.merge_from_list(["on_device_num_threads", args.num_threads])
     cfg.freeze()
 
     assert args.output_dir or args.config_file

--- a/tools/exporter.py
+++ b/tools/exporter.py
@@ -114,6 +114,12 @@ def get_parser():
         help="If set, suppress the exception for failed exporting and continue to"
         " export the next type of model",
     )
+    parser.add_argument(
+        "--num_threads",
+        type=int,
+        default=None,
+        help="Number of threads to be run on device",
+    )
     return parser
 
 


### PR DESCRIPTION
Summary: Number of threads is useful in SDK to set and avoid throttling. Currently for segmentation, the metadata format is tuple, change to map to have better control of keys.

Differential Revision: D31225874

