### PR TITLE
Update tutorial for learnable QAT

### DIFF
--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 from caffe2.proto import caffe2_pb2
 from d2go.export.api import PredictorExportConfig
+from d2go.utils.qat_utils import get_qat_qconfig
 from detectron2.export.caffe2_modeling import (
     META_ARCH_CAFFE2_EXPORT_TYPE_MAP,
     convert_batched_inputs_to_c2_format,
@@ -235,7 +236,9 @@ def default_rcnn_prepare_for_quant(self, cfg):
     model = self
     torch.backends.quantized.engine = cfg.QUANTIZATION.BACKEND
     model.qconfig = (
-        torch.ao.quantization.get_default_qat_qconfig(cfg.QUANTIZATION.BACKEND)
+        get_qat_qconfig(
+            cfg.QUANTIZATION.BACKEND, cfg.QUANTIZATION.QAT.FAKE_QUANT_METHOD
+        )
         if model.training
         else torch.ao.quantization.get_default_qconfig(cfg.QUANTIZATION.BACKEND)
     )


### PR DESCRIPTION
Summary:
Updating `all_steps_qat` example config to use learnable QAT method.

And add logic in `GeneralizedRCNNPatch.prepare_for_quant` to call the new `d2go.utils.qat_utils.get_qat_qconfig` to properly support QAT in D2 (https://github.com/facebookresearch/d2go/commit/7992f91324aee6ae59795063a007c6837e60cdb8)Go training workflow

Differential Revision: D32147216

