### PR TITLE
Parse SuperNet search space from config

### DIFF
--- a/d2go/config/__init__.py
+++ b/d2go/config/__init__.py
@@ -4,6 +4,7 @@
 
 # forward the namespace to avoid `d2go.config.config`
 from .config import (
+    CONFIG_CUSTOM_PARSE_REGISTRY,
     CONFIG_SCALING_METHOD_REGISTRY,
     CfgNode,
     auto_scale_world_size,
@@ -13,6 +14,7 @@ from .config import (
 
 
 __all__ = [
+    "CONFIG_CUSTOM_PARSE_REGISTRY",
     "CONFIG_SCALING_METHOD_REGISTRY",
     "CfgNode",
     "auto_scale_world_size",


### PR DESCRIPTION
Summary:
Add a hook in D2 (https://github.com/facebookresearch/d2go/commit/7992f91324aee6ae59795063a007c6837e60cdb8)Go config for custom parsing so we can support custom objects in D2 (https://github.com/facebookresearch/d2go/commit/7992f91324aee6ae59795063a007c6837e60cdb8)Go config like the search space objects.
Then adding SuperNet custom config processing to parse search space from arch_def when supernet is enabled, so it can be used in D2 (https://github.com/facebookresearch/d2go/commit/7992f91324aee6ae59795063a007c6837e60cdb8)Go SuperNet training.

This is an alternative approach to D33191150. In this approach we parse the entire architecture as a search space which will not have the limitations that we have in parsing only the dynamic blocks parts.

Reviewed By: zhanghang1989

Differential Revision: D33793423

