### PR TITLE
set is_qat properly when fusing model

### DIFF
--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -264,7 +264,11 @@ def default_rcnn_prepare_for_quant(self, cfg):
     # Modify the model for eager mode
     if cfg.QUANTIZATION.EAGER_MODE:
         model = _apply_eager_mode_quant(cfg, model)
-        model = fuse_utils.fuse_model(model, inplace=True)
+        model = fuse_utils.fuse_model(
+            model,
+            is_qat=cfg.QUANTIZATION.QAT.ENABLED,
+            inplace=True,
+        )
     else:
         _fx_quant_prepare(model, cfg)
 

--- a/d2go/modeling/quantization.py
+++ b/d2go/modeling/quantization.py
@@ -251,7 +251,11 @@ def default_prepare_for_quant(cfg, model):
     )
 
     if cfg.QUANTIZATION.EAGER_MODE:
-        model = fuse_utils.fuse_model(model, inplace=True)
+        model = fuse_utils.fuse_model(
+            model,
+            is_qat=cfg.QUANTIZATION.QAT.ENABLED,
+            inplace=True,
+        )
 
         torch.backends.quantized.engine = cfg.QUANTIZATION.BACKEND
         model.qconfig = qconfig


### PR DESCRIPTION
Summary:
D33833203 adds `is_qat` argument to the fuser method, more details in https://fb.workplace.com/groups/2322282031156145/permalink/5026297484087906/. As results, MV's `fuse_utils.fuse_model` then becomes two functions: the original one is for non-qat; a new one `fuse_utils.fuse_model_qat` is for qat.

For D2 (https://github.com/facebookresearch/d2go/commit/7992f91324aee6ae59795063a007c6837e60cdb8)Go in most cases, `is_qat` can be inferred from `cfg.QUANTIZATION.QAT.ENABLED`, therefore we can extend the `fuse_model` to also take `is_qat` as parameter, and set it accordingly.

This diff updates all the call sites which is covered by unit tests. Those call sites include:
- default quantization APIs in d2go/modeling/quantization.py
- customized quantization APIs from individual meta-arch
- unit test itself

Differential Revision: D34112650

