### PR TITLE
Add callout items to the Docs landing page (#12196)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
     "Pillow",
     "mock",
     "torch",
-    "pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@15364c18c",
+    "pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@9b011606f",
     "opencv-python",
     "parameterized",
     "diskcache",  # TODO: move to mobile_cv


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/recipes/pull/14

X-link: https://github.com/facebookresearch/ReAgent/pull/616

### New commit log messages
- [9b011606f Add callout items to the Docs landing page (#12196)](https://github.com/PyTorchLightning/pytorch-lightning/pull/12196)

Reviewed By: edward-io

Differential Revision: D34687261

