### PR TITLE
Cleanup QAT api

### DIFF
--- a/d2go/export/api.py
+++ b/d2go/export/api.py
@@ -114,14 +114,13 @@ def convert_predictor(
                 logger.warn("Post training quantized model has bn inside fused ops")
         logger.info(f"Converting quantized model {cfg.QUANTIZATION.BACKEND}...")
 
-        if cfg.QUANTIZATION.EAGER_MODE:
-            # TODO(T93870278): move this logic to prepare_for_quant_convert
-            pytorch_model = convert(pytorch_model, inplace=False)
-        else:  # FX graph mode quantization
-            if hasattr(pytorch_model, "prepare_for_quant_convert"):
-                pytorch_model = pytorch_model.prepare_for_quant_convert(cfg)
-            else:
-                # TODO(T93870381): move this to a default function
+        if hasattr(pytorch_model, "prepare_for_quant_convert"):
+            pytorch_model = pytorch_model.prepare_for_quant_convert(cfg)
+        else:
+            # TODO(T93870381): move this to a default function
+            if cfg.QUANTIZATION.EAGER_MODE:
+                pytorch_model = convert(pytorch_model, inplace=False)
+            else:  # FX graph mode quantization
                 pytorch_model = convert_fx(pytorch_model)
 
         logger.info("Quantized Model:\n{}".format(pytorch_model))

--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -20,6 +20,7 @@ from mobile_cv.arch.utils.quantize_utils import (
     QuantWrapper,
 )
 from mobile_cv.predictor.api import FuncInfo
+from torch.ao.quantization import convert
 from torch.ao.quantization.quantize_fx import prepare_fx, prepare_qat_fx, convert_fx
 
 logger = logging.getLogger(__name__)
@@ -278,32 +279,32 @@ def default_rcnn_prepare_for_quant(self, cfg):
 @RCNN_PREPARE_FOR_QUANT_CONVERT_REGISTRY.register()
 def default_rcnn_prepare_for_quant_convert(self, cfg):
     if cfg.QUANTIZATION.EAGER_MODE:
-        raise NotImplementedError()
-
-    assert not isinstance(self.backbone, FPN), "FPN is not supported in FX mode"
-    self.backbone = convert_fx(
-        self.backbone,
-        convert_custom_config_dict={"preserved_attributes": ["size_divisibility"]},
-    )
-    self.proposal_generator.rpn_head.rpn_feature = convert_fx(
-        self.proposal_generator.rpn_head.rpn_feature
-    )
-    self.proposal_generator.rpn_head.rpn_regressor.cls_logits = convert_fx(
-        self.proposal_generator.rpn_head.rpn_regressor.cls_logits
-    )
-    self.proposal_generator.rpn_head.rpn_regressor.bbox_pred = convert_fx(
-        self.proposal_generator.rpn_head.rpn_regressor.bbox_pred
-    )
-    self.roi_heads.box_head.roi_box_conv = convert_fx(
-        self.roi_heads.box_head.roi_box_conv
-    )
-    self.roi_heads.box_head.avgpool = convert_fx(self.roi_heads.box_head.avgpool)
-    self.roi_heads.box_predictor.cls_score = convert_fx(
-        self.roi_heads.box_predictor.cls_score
-    )
-    self.roi_heads.box_predictor.bbox_pred = convert_fx(
-        self.roi_heads.box_predictor.bbox_pred
-    )
+        convert(self, inplace=True)
+    else:
+        assert not isinstance(self.backbone, FPN), "FPN is not supported in FX mode"
+        self.backbone = convert_fx(
+            self.backbone,
+            convert_custom_config_dict={"preserved_attributes": ["size_divisibility"]},
+        )
+        self.proposal_generator.rpn_head.rpn_feature = convert_fx(
+            self.proposal_generator.rpn_head.rpn_feature
+        )
+        self.proposal_generator.rpn_head.rpn_regressor.cls_logits = convert_fx(
+            self.proposal_generator.rpn_head.rpn_regressor.cls_logits
+        )
+        self.proposal_generator.rpn_head.rpn_regressor.bbox_pred = convert_fx(
+            self.proposal_generator.rpn_head.rpn_regressor.bbox_pred
+        )
+        self.roi_heads.box_head.roi_box_conv = convert_fx(
+            self.roi_heads.box_head.roi_box_conv
+        )
+        self.roi_heads.box_head.avgpool = convert_fx(self.roi_heads.box_head.avgpool)
+        self.roi_heads.box_predictor.cls_score = convert_fx(
+            self.roi_heads.box_predictor.cls_score
+        )
+        self.roi_heads.box_predictor.bbox_pred = convert_fx(
+            self.roi_heads.box_predictor.bbox_pred
+        )
     return self
 
 


### PR DESCRIPTION
Summary:
Currently there is some fragmentation in export for how to apply convert logic in various mode. `prepare_for_quant_convert` is only called in non eager modes and the logic in eager mode is not customizable.
This diff unify the `prepare_for_quant_convert` code path for all quantization modes.
Also in this diff we rename `_non_qat_to_qat_state_dict_map`, that is use in qat checkpointer to be publish var `non_qat_to_qat_state_dict_map` and allow models to populate it with custom mapping. This is useful in cases where the param mapping between the non qat model and the qat model cannot be inferred definitely (see note in https://fburl.com/code/9rx172ht) and have some ambiguity that can only be resolved by the model logic.

Differential Revision: D34741217

