### PR TITLE
support force exporting gpu model for rcnn meta_arch

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -29,4 +29,4 @@ jobs:
         env:
             OSSRUN: 1
         run: |
-          python -m unittest discover tests
+          python -m unittest discover -v -s tests

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,9 +1,13 @@
-name: Unit Test
+name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"  # @daily
 
 jobs:
-  build:
+  python-unittest:
 
     runs-on: ubuntu-latest
 

--- a/d2go/utils/testing/rcnn_helper.py
+++ b/d2go/utils/testing/rcnn_helper.py
@@ -180,8 +180,10 @@ class MockRCNNInference(object):
         return results
 
 
-def _validate_outputs(inputs, outputs):
+def _validate_outputs(inputs, outputs, is_gpu=False):
     assert len(inputs) == len(outputs)
+    if is_gpu:
+        assert outputs[0]["instances"].pred_classes.device.type == "cuda"
     # TODO: figure out how to validate outputs
 
 
@@ -311,7 +313,8 @@ class RCNNBaseTestCases:
 
                 predictor = create_predictor(predictor_path)
                 predictor_outputs = predictor(inputs)
-                _validate_outputs(inputs, predictor_outputs)
+                is_gpu = self.cfg.MODEL.DEVICE != "cpu" or "_gpu" in predictor_type
+                _validate_outputs(inputs, predictor_outputs, is_gpu=is_gpu)
 
                 if compare_match:
                     with torch.no_grad():

--- a/tests/misc/test_lightning_train_net.py
+++ b/tests/misc/test_lightning_train_net.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 import numpy as np
+import torch.distributed as dist
 from d2go.config import CfgNode
 from d2go.config.utils import flatten_config_dict
 from d2go.runner.lightning_task import GeneralizedRCNNTask
@@ -56,3 +57,7 @@ class TestLightningTrainNet(unittest.TestCase):
         accuracy2 = flatten_config_dict(out2.accuracy)
         for k in accuracy:
             np.testing.assert_equal(accuracy[k], accuracy2[k])
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()

--- a/tests/modeling/test_meta_arch_rcnn.py
+++ b/tests/modeling/test_meta_arch_rcnn.py
@@ -19,6 +19,14 @@ from mobile_cv.common.misc.file_utils import make_temp_directory
 patch_d2_meta_arch()
 
 
+def _maybe_skip_test(self, predictor_type):
+    if os.getenv("OSSRUN") == "1" and "@c2_ops" in predictor_type:
+        self.skipTest("Caffe2 is not available for OSS")
+
+    if not torch.cuda.is_available() and "_gpu" in predictor_type:
+        self.skipTest("GPU is not available for exporting GPU model")
+
+
 class TestFBNetV3MaskRCNNFP32(RCNNBaseTestCases.TemplateTestCase):
     def setup_custom_test(self):
         super().setup_custom_test()
@@ -31,13 +39,13 @@ class TestFBNetV3MaskRCNNFP32(RCNNBaseTestCases.TemplateTestCase):
         [
             ["torchscript@c2_ops", True],
             ["torchscript", True],
+            ["torchscript_gpu", False],  # can't compare across device
             ["torchscript_int8@c2_ops", False],
             ["torchscript_int8", False],
         ]
     )
     def test_export(self, predictor_type, compare_match):
-        if os.getenv("OSSRUN") == "1" and "@c2_ops" in predictor_type:
-            self.skipTest("Caffe2 is not available for OSS")
+        _maybe_skip_test(self, predictor_type)
         self._test_export(predictor_type, compare_match=compare_match)
 
 
@@ -58,8 +66,7 @@ class TestFBNetV3MaskRCNNFPNFP32(RCNNBaseTestCases.TemplateTestCase):
         ]
     )
     def test_export(self, predictor_type, compare_match):
-        if os.getenv("OSSRUN") == "1" and "@c2_ops" in predictor_type:
-            self.skipTest("Caffe2 is not available for OSS")
+        _maybe_skip_test(self, predictor_type)
         self._test_export(predictor_type, compare_match=compare_match)
 
 
@@ -89,8 +96,7 @@ class TestFBNetV3MaskRCNNQATEager(RCNNBaseTestCases.TemplateTestCase):
         ]
     )
     def test_export(self, predictor_type, compare_match):
-        if os.getenv("OSSRUN") == "1" and "@c2_ops" in predictor_type:
-            self.skipTest("Caffe2 is not available for OSS")
+        _maybe_skip_test(self, predictor_type)
         self._test_export(predictor_type, compare_match=compare_match)
 
 


### PR DESCRIPTION
Summary:
When exporting model to torchscript (using `MODEL.DEVICE = "cpu"`), mean/std are constant instead of model parameters. Therefore after casting the torchscript to CUDA, the mean/std remains on cpu. This will cause problem when running inference on GPU.

The fix is exporting the model with `MODEL.DEVICE = "cuda"`. However D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go internally uses "cpu" during export (via cli: https://fburl.com/code/4mpk153i, via workflow: https://fburl.com/code/zcj5ud4u) by default. For CLI, user can manually set `--device`, but for workflow it's hard to do so. Further more it's hard to support mixed model using single `--device` option. So this diff adds a special handling in the RCNN's `default_prepare_for_export` to bypass the `--device` option.

Differential Revision: D35097613

