### PR TITLE
support do_postprocess when tracing rcnn model in D2 style

### DIFF
--- a/d2go/modeling/subclass.py
+++ b/d2go/modeling/subclass.py
@@ -43,6 +43,9 @@ class SubclassFetcher(ABC):
     to use with custom projects.
     """
 
+    def __init__(self, cfg):
+        raise NotImplementedError()
+
     @property
     @abstractmethod
     def subclass_names(self) -> List[str]:

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -618,6 +618,12 @@ def _add_rcnn_default_config(_C):
     _C.EXPORT_CAFFE2 = CfgNode()
     _C.EXPORT_CAFFE2.USE_HEATMAP_MAX_KEYPOINT = False
 
+    # Options about how to export the model
+    _C.RCNN_EXPORT = CfgNode()
+    # whether or not to include the postprocess (GeneralizedRCNN._postprocess) step
+    # inside the exported model
+    _C.RCNN_EXPORT.INCLUDE_POSTPROCESS = False
+
     _C.RCNN_PREPARE_FOR_EXPORT = "default_rcnn_prepare_for_export"
     _C.RCNN_PREPARE_FOR_QUANT = "default_rcnn_prepare_for_quant"
     _C.RCNN_PREPARE_FOR_QUANT_CONVERT = "default_rcnn_prepare_for_quant_convert"

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -11,7 +11,7 @@ from d2go.data.disk_cache import DiskCachedDatasetFromList
 from d2go.data.utils import enable_disk_cached_dataset
 from d2go.runner import create_runner
 from d2go.utils.testing.data_loader_helper import (
-    create_fake_detection_data_loader,
+    create_detection_data_loader_on_toy_dataset,
     register_toy_coco_dataset,
 )
 
@@ -102,16 +102,16 @@ class TestDiskCachedDataLoader(unittest.TestCase):
             # no cache dir in the beginning
             self.assertEqual(self._count_cache_dirs(), 0)
 
-            with create_fake_detection_data_loader(
-                height, width, is_train=True
+            with create_detection_data_loader_on_toy_dataset(
+                cfg, height, width, is_train=True
             ) as train_loader:
                 # train loader should create one cache dir
                 self.assertEqual(self._count_cache_dirs(), 1)
 
                 _test_data_loader(train_loader)
 
-                with create_fake_detection_data_loader(
-                    height, width, is_train=False
+                with create_detection_data_loader_on_toy_dataset(
+                    cfg, height, width, is_train=False
                 ) as test_loader:
                     # test loader should create another cache dir
                     self.assertEqual(self._count_cache_dirs(), 2)

--- a/tests/misc/test_flop_count.py
+++ b/tests/misc/test_flop_count.py
@@ -2,7 +2,9 @@ import os
 import tempfile
 
 from d2go.utils.flop_calculator import dump_flops_info
-from d2go.utils.testing.data_loader_helper import create_fake_detection_data_loader
+from d2go.utils.testing.data_loader_helper import (
+    create_detection_data_loader_on_toy_dataset,
+)
 from d2go.utils.testing.rcnn_helper import RCNNBaseTestCases
 
 
@@ -14,7 +16,9 @@ class TestFlopCount(RCNNBaseTestCases.TemplateTestCase):
     def test_flop_count(self):
         size_divisibility = max(self.test_model.backbone.size_divisibility, 10)
         h, w = size_divisibility, size_divisibility * 2
-        with create_fake_detection_data_loader(h, w, is_train=False) as data_loader:
+        with create_detection_data_loader_on_toy_dataset(
+            self.cfg, h, w, is_train=False
+        ) as data_loader:
             inputs = (next(iter(data_loader)),)
 
         with tempfile.TemporaryDirectory(prefix="d2go_test") as output_dir:

--- a/tests/modeling/test_meta_arch_rcnn.py
+++ b/tests/modeling/test_meta_arch_rcnn.py
@@ -191,5 +191,19 @@ class TestTorchVisionExport(unittest.TestCase):
                 scripted_model.save(os.path.join(tmp_dir, "new_file.pt"))
 
 
+class TestMaskRCNNExportOptions(RCNNBaseTestCases.TemplateTestCase):
+    def setup_custom_test(self):
+        super().setup_custom_test()
+        self.cfg.merge_from_file("detectron2go://mask_rcnn_fbnetv3a_dsmask_C4.yaml")
+
+    def _get_test_image_sizes(self, is_train):
+        # postprocessing requires no resize from "data loader"
+        return self._get_test_image_size_no_resize(is_train)
+
+    def test_tracing_with_postprocess(self):
+        self.cfg.merge_from_list(["RCNN_EXPORT.INCLUDE_POSTPROCESS", True])
+        self._test_export("torchscript@tracing", compare_match=True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Currently when exporting the RCNN model, we call it with `self.model.inference(inputs, do_postprocess=False)[0]`, therefore the output of exported model is not post-processed, eg. the mask is in the squared shape. This diff adds the option to include postprocess in the exported model.

Worth noting that since the input is a single tensor, the post-process doesn't resize the output to original resolution, and we can't apply the post-process twice to further resize it in the Predictor's PostProcessFunc, add an assertion to raise error in this case. But this is fine for most production use cases where the input is not resized.

Set `RCNN_EXPORT.INCLUDE_POSTPROCESS` to `True` to enable this.

Differential Revision: D34904058

