### PR TITLE
Use build_model in d2go in default_runner instead of the version in d2.

### DIFF
--- a/d2go/data/transforms/__init__.py
+++ b/d2go/data/transforms/__init__.py
@@ -3,12 +3,5 @@
 
 
 # import all modules to make sure Registry works
-# @fb-only: from . import (  # noqa  # noqa 
-    affine,
-    blur,
-    box_utils,
-    color_yuv,
-    crop,
-    d2_native,
-    fb,
-)
+# @fb-only: from . import fb  # isort:skip  # noqa 
+from . import affine, blur, box_utils, color_yuv, crop, d2_native  # noqa

--- a/d2go/modeling/meta_arch/__init__.py
+++ b/d2go/modeling/meta_arch/__init__.py
@@ -2,4 +2,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 # NOTE: making necessary imports to register with Registry
-from . import fb, fcos  # noqa  # @fb-only  # noqa
+# @fb-only: from . import fb  # isort:skip  # noqa 
+from . import fcos  # noqa

--- a/d2go/modeling/meta_arch/modeling_hook.py
+++ b/d2go/modeling/meta_arch/modeling_hook.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from abc import abstractmethod
+
+import torch
+
+
+class ModelingHook(object):
+    """Modeling hooks provide a way to modify the model during the model building
+    process. It is simple but allows users to modify the model by creating wrapper,
+    override member functions, adding additional components, and loss etc.. It
+    could be used to implement features such as QAT, model transformation for training,
+    distillation/semi-supervised learning, and customization for loading pre-trained
+    weights.
+    """
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    @abstractmethod
+    def apply(self, model: torch.nn.Module) -> torch.nn.Module:
+        """This function will called during the model building process to modify
+        the behavior of the input model.
+        The created model will be
+          model == create meta arch -> model_hook_1.apply(model) ->
+            model_hook_2.apply(model) -> ...
+        """
+        pass
+
+    @abstractmethod
+    def unapply(self, model: torch.nn.Module) -> torch.nn.Module:
+        """This function will be called when the users called model.get_exportable_model()
+        after training. The main use case of the function is to remove the changes
+        applied to the model in `apply`. The hooks will be called in reverse order
+        as follow:
+          model.get_exportable_model() == model_hook_N.unapply(model) ->
+              model_hook_N-1.unapply(model) -> ... -> model_hook_1.unapply(model)
+        """
+        pass

--- a/d2go/modeling/modeldef/__init__.py
+++ b/d2go/modeling/modeldef/__init__.py
@@ -6,4 +6,5 @@
 This is the centralized place to define modeldef for all projects under D2Go.
 """
 
-from . import fb, modeldef  # noqa  # @fb-only  # noqa
+# @fb-only: from . import fb  # isort:skip  # noqa 
+from . import modeldef  # noqa

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -23,7 +23,7 @@ from d2go.data.utils import (
     update_cfg_if_using_adhoc_dataset,
 )
 from d2go.export.d2_meta_arch import patch_d2_meta_arch
-from d2go.modeling import kmeans_anchors, model_ema
+from d2go.modeling import build_model, kmeans_anchors, model_ema
 from d2go.modeling.model_freezing_utils import freeze_matched_bn, set_requires_grad
 from d2go.optimizer import build_optimizer_mapper
 from d2go.quantization.modeling import QATCheckpointer, QATHook, setup_qat_model
@@ -48,7 +48,7 @@ from detectron2.evaluation import (
     RotatedCOCOEvaluator,
     verify_results,
 )
-from detectron2.modeling import build_model, GeneralizedRCNNWithTTA
+from detectron2.modeling import GeneralizedRCNNWithTTA
 from detectron2.solver import build_lr_scheduler as d2_build_lr_scheduler
 from detectron2.utils.events import CommonMetricPrinter, JSONWriter
 from detectron2.utils.registry import Registry

--- a/d2go/utils/__init__.py
+++ b/d2go/utils/__init__.py
@@ -3,4 +3,6 @@
 
 
 # import to make sure Registry works
-from . import fb, flop_calculator  # noqa  # @fb-only  # noqa
+# usort does not respect the `fb-only` tag so use isort:skip here
+# @fb-only: from . import fb  # isort:skip  # noqa 
+from . import flop_calculator  # noqa

--- a/tests/modeling/test_modeling_meta_arch_modeling_hook.py
+++ b/tests/modeling/test_modeling_meta_arch_modeling_hook.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+
+import unittest
+
+import torch
+from d2go.modeling.meta_arch import modeling_hook as mh
+
+
+class TestArch(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return x * 2
+
+
+# create a wrapper of the model that add 1 to the output
+class Wrapper(torch.nn.Module):
+    def __init__(self, model: TestArch):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x):
+        return self.model(x) + 1
+
+
+class PlusOneHook(mh.ModelingHook):
+    def __init__(self, cfg):
+        super().__init__(cfg)
+
+    def apply(self, model: torch.nn.Module) -> torch.nn.Module:
+        return Wrapper(model)
+
+    def unapply(self, model: torch.nn.Module) -> torch.nn.Module:
+        assert isinstance(model, Wrapper)
+        return model.model
+
+
+class TestModelingHook(unittest.TestCase):
+    def test_modeling_hook_simple(self):
+        model = TestArch()
+        hook = PlusOneHook(None)
+        model_with_hook = hook.apply(model)
+        self.assertEqual(model_with_hook(2), 5)
+        original_model = hook.unapply(model_with_hook)
+        self.assertEqual(model, original_model)


### PR DESCRIPTION
Summary: Use build_model in d2go in default_runner instead of the version in d2.

Differential Revision: D35535568

