### PR TITLE
Align_corners cannot be set when mode is nearest

### DIFF
--- a/d2go/modeling/backbone/modules.py
+++ b/d2go/modeling/backbone/modules.py
@@ -145,8 +145,6 @@ class KeypointRCNNConvUpsamplePredictorNoUpscale(nn.Module):
         self.out_channels = num_keypoints
 
     def forward(self, x):
-        x = layers.interpolate(
-            x, scale_factor=(2, 2), mode="nearest", align_corners=False
-        )
+        x = layers.interpolate(x, scale_factor=(2, 2), mode="nearest")
         x = self.kps_score_lowres(x)
         return x


### PR DESCRIPTION
Summary: Align_core cannot be set if the mode is nearest. Change to default None.

Differential Revision: D35681284

