### PR TITLE
apply import merging for fbcode/mobile-vision/d2go (3 of 4)

### DIFF
--- a/projects_oss/detr/detr/__init__.py
+++ b/projects_oss/detr/detr/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from . import models, util, datasets
+from . import datasets, models, util
 
 __all__ = ["models", "util", "datasets"]

--- a/projects_oss/detr/detr/backbone/deit.py
+++ b/projects_oss/detr/detr/backbone/deit.py
@@ -14,7 +14,7 @@ from detectron2.utils.file_io import PathManager
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
 from timm.models.layers import trunc_normal_
 from timm.models.registry import register_model
-from timm.models.vision_transformer import VisionTransformer, PatchEmbed
+from timm.models.vision_transformer import PatchEmbed, VisionTransformer
 
 
 def monkey_patch_forward(self, x):

--- a/projects_oss/detr/detr/d2/dataset_mapper.py
+++ b/projects_oss/detr/detr/d2/dataset_mapper.py
@@ -6,8 +6,7 @@ import logging
 
 import numpy as np
 import torch
-from detectron2.data import detection_utils as utils
-from detectron2.data import transforms as T
+from detectron2.data import detection_utils as utils, transforms as T
 
 __all__ = ["DetrDatasetMapper"]
 

--- a/projects_oss/detr/detr/d2/detr.py
+++ b/projects_oss/detr/detr/d2/detr.py
@@ -3,8 +3,8 @@
 import numpy as np
 import torch
 import torch.nn.functional as F
-from detectron2.modeling import META_ARCH_REGISTRY, detector_postprocess
-from detectron2.structures import Boxes, ImageList, Instances, BitMasks
+from detectron2.modeling import detector_postprocess, META_ARCH_REGISTRY
+from detectron2.structures import BitMasks, Boxes, ImageList, Instances
 from detr.datasets.coco import convert_coco_poly_to_mask
 from detr.models.backbone import Joiner
 from detr.models.build import build_detr_model
@@ -14,7 +14,7 @@ from detr.models.detr import DETR
 from detr.models.matcher import HungarianMatcher
 from detr.models.position_encoding import PositionEmbeddingSine
 from detr.models.segmentation import DETRsegm, PostProcessSegm
-from detr.models.setcriterion import SetCriterion, FocalLossSetCriterion
+from detr.models.setcriterion import FocalLossSetCriterion, SetCriterion
 from detr.util.box_ops import box_cxcywh_to_xyxy, box_xyxy_to_cxcywh
 from detr.util.misc import NestedTensor
 from torch import nn

--- a/projects_oss/detr/detr/datasets/ade.py
+++ b/projects_oss/detr/detr/datasets/ade.py
@@ -10,7 +10,7 @@ import torch.utils.data as data
 import torchvision
 import torchvision.transforms as transform
 from detectron2.utils.file_io import PathManager
-from PIL import Image, ImageOps, ImageFilter
+from PIL import Image, ImageFilter, ImageOps
 
 from .coco import make_coco_transforms
 

--- a/projects_oss/detr/detr/functions/ms_deform_attn_func.py
+++ b/projects_oss/detr/detr/functions/ms_deform_attn_func.py
@@ -8,9 +8,7 @@
 # Modified from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/tree/pytorch_1.0.0
 # ------------------------------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import torch
 import torch.nn.functional as F

--- a/projects_oss/detr/detr/models/backbone.py
+++ b/projects_oss/detr/detr/models/backbone.py
@@ -18,7 +18,7 @@ from typing import Dict, List
 import torch
 import torch.nn.functional as F
 import torchvision
-from detr.util.misc import NestedTensor, is_main_process
+from detr.util.misc import is_main_process, NestedTensor
 from torch import nn
 from torchvision.models._utils import IntermediateLayerGetter
 

--- a/projects_oss/detr/detr/models/deformable_detr.py
+++ b/projects_oss/detr/detr/models/deformable_detr.py
@@ -20,22 +20,22 @@ from torch import nn
 
 from ..util import box_ops
 from ..util.misc import (
-    NestedTensor,
-    nested_tensor_from_tensor_list,
     accuracy,
     get_world_size,
     interpolate,
     is_dist_avail_and_initialized,
+    nested_tensor_from_tensor_list,
+    NestedTensor,
 )
 from .backbone import build_backbone
-from .build import DETR_MODEL_REGISTRY, build_detr_backbone
+from .build import build_detr_backbone, DETR_MODEL_REGISTRY
 from .deformable_transformer import DeformableTransformer
 from .matcher import build_matcher
 from .segmentation import (
     DETRsegm,
+    dice_loss,
     PostProcessPanoptic,
     PostProcessSegm,
-    dice_loss,
     sigmoid_focal_loss,
 )
 from .setcriterion import FocalLossSetCriterion

--- a/projects_oss/detr/detr/models/deformable_transformer.py
+++ b/projects_oss/detr/detr/models/deformable_transformer.py
@@ -12,7 +12,7 @@ import math
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.nn.init import xavier_uniform_, constant_, normal_
+from torch.nn.init import constant_, normal_, xavier_uniform_
 
 from ..modules import MSDeformAttn
 from ..util.misc import inverse_sigmoid

--- a/projects_oss/detr/detr/models/detr.py
+++ b/projects_oss/detr/detr/models/detr.py
@@ -9,27 +9,27 @@ import torch.nn.functional as F
 from detectron2.config import configurable
 from detr.util import box_ops
 from detr.util.misc import (
-    NestedTensor,
-    nested_tensor_from_tensor_list,
     accuracy,
     get_world_size,
     interpolate,
     is_dist_avail_and_initialized,
+    nested_tensor_from_tensor_list,
+    NestedTensor,
 )
 from torch import nn
 
 from .backbone import build_backbone
-from .build import DETR_MODEL_REGISTRY, build_detr_backbone
+from .build import build_detr_backbone, DETR_MODEL_REGISTRY
 from .matcher import build_matcher
 from .segmentation import (
     DETRsegm,
+    dice_loss,
     PostProcessPanoptic,
     PostProcessSegm,
-    dice_loss,
     sigmoid_focal_loss,
 )
 from .setcriterion import SetCriterion
-from .transformer import Transformer, build_transformer
+from .transformer import build_transformer, Transformer
 
 
 @DETR_MODEL_REGISTRY.register()

--- a/projects_oss/detr/detr/models/segmentation.py
+++ b/projects_oss/detr/detr/models/segmentation.py
@@ -12,7 +12,7 @@ import detr.util.box_ops as box_ops
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from detr.util.misc import NestedTensor, interpolate, nested_tensor_from_tensor_list
+from detr.util.misc import interpolate, nested_tensor_from_tensor_list, NestedTensor
 from PIL import Image
 from torch import Tensor
 

--- a/projects_oss/detr/detr/models/setcriterion.py
+++ b/projects_oss/detr/detr/models/setcriterion.py
@@ -6,11 +6,11 @@ from torch import nn
 
 from ..util import box_ops
 from ..util.misc import (
-    nested_tensor_from_tensor_list,
     accuracy,
     get_world_size,
     interpolate,
     is_dist_avail_and_initialized,
+    nested_tensor_from_tensor_list,
 )
 from .segmentation import dice_loss, sigmoid_focal_loss
 

--- a/projects_oss/detr/detr/modules/ms_deform_attn.py
+++ b/projects_oss/detr/detr/modules/ms_deform_attn.py
@@ -8,9 +8,7 @@
 # Modified from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/tree/pytorch_1.0.0
 # ------------------------------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import math
 import warnings
@@ -18,7 +16,7 @@ import warnings
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.nn.init import xavier_uniform_, constant_
+from torch.nn.init import constant_, xavier_uniform_
 
 from ..functions import MSDeformAttnFunction
 

--- a/projects_oss/detr/detr/runner.py
+++ b/projects_oss/detr/detr/runner.py
@@ -6,7 +6,7 @@ from d2go.data.dataset_mappers.d2go_dataset_mapper import D2GoDatasetMapper
 from d2go.runner import GeneralizedRCNNRunner
 from detr.backbone.deit import add_deit_backbone_config
 from detr.backbone.pit import add_pit_backbone_config
-from detr.d2 import DetrDatasetMapper, add_detr_config
+from detr.d2 import add_detr_config, DetrDatasetMapper
 
 
 @D2GO_DATA_MAPPER_REGISTRY.register()

--- a/projects_oss/detr/detr/util/misc.py
+++ b/projects_oss/detr/detr/util/misc.py
@@ -13,7 +13,7 @@ import subprocess
 import time
 from collections import defaultdict, deque
 from distutils.version import LooseVersion
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 import torch.distributed as dist

--- a/projects_oss/detr/setup.py
+++ b/projects_oss/detr/setup.py
@@ -10,11 +10,8 @@ import glob
 import os
 
 import torch
-from setuptools import find_packages
-from setuptools import setup
-from torch.utils.cpp_extension import CUDAExtension
-from torch.utils.cpp_extension import CUDA_HOME
-from torch.utils.cpp_extension import CppExtension
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import CppExtension, CUDA_HOME, CUDAExtension
 
 requirements = ["torch", "torchvision"]
 

--- a/projects_oss/detr/test_all.py
+++ b/projects_oss/detr/test_all.py
@@ -9,8 +9,8 @@ from detr.hub import detr_resnet50, detr_resnet50_panoptic
 from detr.models.backbone import Backbone
 from detr.models.matcher import HungarianMatcher
 from detr.models.position_encoding import (
-    PositionEmbeddingSine,
     PositionEmbeddingLearned,
+    PositionEmbeddingSine,
 )
 from detr.util import box_ops
 from detr.util.misc import nested_tensor_from_tensor_list

--- a/projects_oss/detr/test_op.py
+++ b/projects_oss/detr/test_op.py
@@ -14,8 +14,8 @@ from functools import wraps
 
 import torch
 from detr.functions.ms_deform_attn_func import (
-    MSDeformAttnFunction,
     ms_deform_attn_core_pytorch,
+    MSDeformAttnFunction,
 )
 from torch.autograd import gradcheck
 

--- a/tests/data/test_d2go_datasets.py
+++ b/tests/data/test_d2go_datasets.py
@@ -8,21 +8,21 @@ import tempfile
 import unittest
 
 import d2go.data.extended_coco as extended_coco
-from d2go.data.datasets import COCO_REGISTER_FUNCTION_REGISTRY, ANN_FN, IM_DIR
+from d2go.data.datasets import ANN_FN, COCO_REGISTER_FUNCTION_REGISTRY, IM_DIR
 from d2go.data.keypoint_metadata_registry import (
+    get_keypoint_metadata,
     KEYPOINT_METADATA_REGISTRY,
     KeypointMetadata,
-    get_keypoint_metadata,
 )
 from d2go.data.utils import (
-    maybe_subsample_n_images,
     AdhocDatasetManager,
     COCOWithClassesToUse,
+    maybe_subsample_n_images,
 )
 from d2go.runner import Detectron2GoRunner
 from d2go.utils.testing.data_loader_helper import (
-    LocalImageGenerator,
     create_toy_dataset,
+    LocalImageGenerator,
 )
 from d2go.utils.testing.helper import tempdir
 from detectron2.data import DatasetCatalog, MetadataCatalog

--- a/tests/data/test_data_transforms_crop.py
+++ b/tests/data/test_data_transforms_crop.py
@@ -162,10 +162,7 @@ class TestDataTransformsCrop(unittest.TestCase):
 
     def test_random_instance_crop(self):
         from detectron2.data import detection_utils as du
-        from detectron2.data.transforms.augmentation import (
-            AugInput,
-            AugmentationList,
-        )
+        from detectron2.data.transforms.augmentation import AugInput, AugmentationList
         from detectron2.structures import BoxMode
 
         aug = tf_crop.RandomInstanceCrop([1.0, 1.0])

--- a/tests/export/test_api.py
+++ b/tests/export/test_api.py
@@ -10,8 +10,8 @@ import torch
 import torch.nn as nn
 from d2go.export.api import (
     convert_and_export_predictor,
-    PredictorExportConfig,
     FuncInfo,
+    PredictorExportConfig,
 )
 from d2go.export.fb.caffe2 import DefaultCaffe2Export
 from d2go.export.torchscript import (


### PR DESCRIPTION
Summary:
Applies new import merging and sorting from µsort v1.0.

When merging imports, µsort will make a best-effort to move associated
comments to match merged elements, but there are known limitations due to
the diynamic nature of Python and developer tooling. These changes should
not produce any dangerous runtime changes, but may require touch-ups to
satisfy linters and other tooling.

Note that µsort uses case-insensitive, lexicographical sorting, which
results in a different ordering compared to isort. This provides a more
consistent sorting order, matching the case-insensitive order used when
sorting import statements by module name, and ensures that "frog", "FROG",
and "Frog" always sort next to each other.

For details on µsort's sorting and merging semantics, see the user guide:
https://usort.readthedocs.io/en/stable/guide.html#sorting

Reviewed By: jreese

Differential Revision: D35559673

