### PR TITLE
apply import merging for fbcode/mobile-vision/d2go (4 of 4)

### DIFF
--- a/tests/misc/test_config.py
+++ b/tests/misc/test_config.py
@@ -7,8 +7,7 @@ import logging
 import os
 import unittest
 
-from d2go.config import CfgNode
-from d2go.config import auto_scale_world_size, reroute_config_path
+from d2go.config import auto_scale_world_size, CfgNode, reroute_config_path
 from d2go.config.utils import (
     config_dict_to_list_str,
     flatten_config_dict,

--- a/tests/misc/test_lightning_train_net.py
+++ b/tests/misc/test_lightning_train_net.py
@@ -9,7 +9,7 @@ import torch.distributed as dist
 from d2go.config import CfgNode
 from d2go.config.utils import flatten_config_dict
 from d2go.runner.lightning_task import GeneralizedRCNNTask
-from d2go.tools.lightning_train_net import main, FINAL_MODEL_CKPT
+from d2go.tools.lightning_train_net import FINAL_MODEL_CKPT, main
 from d2go.utils.testing import meta_arch_helper as mah
 from d2go.utils.testing.helper import tempdir
 

--- a/tests/misc/test_startup_time.py
+++ b/tests/misc/test_startup_time.py
@@ -4,11 +4,7 @@
 
 import unittest
 
-from d2go.initializer import (
-    REGISTER_D2_DATASETS_TIME,
-    REGISTER_TIME,
-    SETUP_ENV_TIME,
-)
+from d2go.initializer import REGISTER_D2_DATASETS_TIME, REGISTER_TIME, SETUP_ENV_TIME
 
 
 class TestStartupTime(unittest.TestCase):

--- a/tests/modeling/test_meta_arch_rcnn.py
+++ b/tests/modeling/test_meta_arch_rcnn.py
@@ -13,7 +13,7 @@ from d2go.runner import GeneralizedRCNNRunner
 from d2go.utils.testing.data_loader_helper import (
     create_detection_data_loader_on_toy_dataset,
 )
-from d2go.utils.testing.rcnn_helper import RCNNBaseTestCases, get_quick_test_config_opts
+from d2go.utils.testing.rcnn_helper import get_quick_test_config_opts, RCNNBaseTestCases
 from mobile_cv.common.misc.file_utils import make_temp_directory
 
 # Add APIs to D2's meta arch, this is usually called in runner's setup, however in
@@ -144,7 +144,7 @@ class TestTorchVisionExport(unittest.TestCase):
         cfg.merge_from_list(["MODEL.DEVICE", "cpu"])
         pytorch_model = runner.build_model(cfg, eval_only=True)
 
-        from typing import List, Dict
+        from typing import Dict, List
 
         class Wrapper(torch.nn.Module):
             def __init__(self, model):

--- a/tests/modeling/test_optimizer.py
+++ b/tests/modeling/test_optimizer.py
@@ -7,9 +7,7 @@ import unittest
 
 import d2go.runner.default_runner as default_runner
 import torch
-from d2go.optimizer import (
-    build_optimizer_mapper,
-)
+from d2go.optimizer import build_optimizer_mapper
 from d2go.utils.testing import helper
 
 

--- a/tests/runner/test_runner_lightning_quantization.py
+++ b/tests/runner/test_runner_lightning_quantization.py
@@ -7,18 +7,18 @@ import unittest
 import mock
 import torch
 from d2go.runner.callbacks.quantization import (
+    get_default_qat_qconfig,
+    ModelTransform,
     PostTrainingQuantization,
     QuantizationAwareTraining,
-    ModelTransform,
-    get_default_qat_qconfig,
     rgetattr,
-    rsetattr,
     rhasattr,
+    rsetattr,
 )
 from d2go.utils.misc import mode
 from d2go.utils.testing.helper import tempdir
 from d2go.utils.testing.lightning_test_module import TestModule
-from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning import seed_everything, Trainer
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from torch.ao.quantization import (  # @manual; @manual
     default_dynamic_qconfig,

--- a/tests/runner/test_runner_lightning_task.py
+++ b/tests/runner/test_runner_lightning_task.py
@@ -11,9 +11,7 @@ import pytorch_lightning as pl  # type: ignore
 import torch
 from d2go.config import CfgNode, temp_defrost
 from d2go.runner import create_runner
-from d2go.runner.callbacks.quantization import (
-    QuantizationAwareTraining,
-)
+from d2go.runner.callbacks.quantization import QuantizationAwareTraining
 from d2go.runner.lightning_task import GeneralizedRCNNTask
 from d2go.utils.testing import meta_arch_helper as mah
 from d2go.utils.testing.helper import tempdir
@@ -21,7 +19,7 @@ from detectron2.modeling import META_ARCH_REGISTRY
 from detectron2.utils.events import EventStorage
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from torch import Tensor
-from torch.ao.quantization.quantize_fx import prepare_qat_fx, convert_fx
+from torch.ao.quantization.quantize_fx import convert_fx, prepare_qat_fx
 
 
 class TestLightningTask(unittest.TestCase):

--- a/tests/utils/test_visualization.py
+++ b/tests/utils/test_visualization.py
@@ -6,17 +6,17 @@ import copy
 import json
 import os
 import unittest
-from typing import Optional, List, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
 
 import d2go.runner.default_runner as default_runner
 import numpy as np
 import torch
 from d2go.utils.testing.data_loader_helper import (
-    LocalImageGenerator,
     create_toy_dataset,
+    LocalImageGenerator,
 )
 from d2go.utils.testing.helper import tempdir
-from d2go.utils.visualization import VisualizerWrapper, DataLoaderVisWrapper
+from d2go.utils.visualization import DataLoaderVisWrapper, VisualizerWrapper
 from detectron2.data import DatasetCatalog
 from detectron2.modeling import META_ARCH_REGISTRY
 from detectron2.structures import Boxes, Instances

--- a/tools/benchmark_data.py
+++ b/tools/benchmark_data.py
@@ -9,7 +9,7 @@ import time
 
 import detectron2.utils.comm as comm
 import numpy as np
-from d2go.distributed import launch, get_num_processes_per_machine
+from d2go.distributed import get_num_processes_per_machine, launch
 from d2go.setup import (
     basic_argument_parser,
     post_mortem_if_fail_for_main,

--- a/tools/exporter.py
+++ b/tools/exporter.py
@@ -14,11 +14,7 @@ import typing
 import mobile_cv.lut.lib.pt.flops_utils as flops_utils
 from d2go.config import temp_defrost
 from d2go.export.api import convert_and_export_predictor
-from d2go.setup import (
-    basic_argument_parser,
-    prepare_for_launch,
-    setup_after_launch,
-)
+from d2go.setup import basic_argument_parser, prepare_for_launch, setup_after_launch
 from mobile_cv.common.misc.py import post_mortem_if_fail
 
 

--- a/tools/lightning_train_net.py
+++ b/tools/lightning_train_net.py
@@ -8,17 +8,15 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type
 
 import pytorch_lightning as pl  # type: ignore
-from d2go.config import CfgNode, temp_defrost, auto_scale_world_size
+from d2go.config import auto_scale_world_size, CfgNode, temp_defrost
 from d2go.runner import create_runner
-from d2go.runner.callbacks.quantization import (
-    QuantizationAwareTraining,
-)
+from d2go.runner.callbacks.quantization import QuantizationAwareTraining
 from d2go.runner.lightning_task import GeneralizedRCNNTask
 from d2go.setup import basic_argument_parser
 from d2go.utils.misc import dump_trained_model_configs
 from detectron2.utils.events import EventStorage
 from detectron2.utils.file_io import PathManager
-from pytorch_lightning.callbacks import Callback, TQDMProgressBar, LearningRateMonitor
+from pytorch_lightning.callbacks import Callback, LearningRateMonitor, TQDMProgressBar
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.strategies.ddp import DDPStrategy

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -16,7 +16,7 @@ from d2go.setup import (
     prepare_for_launch,
     setup_after_launch,
 )
-from d2go.utils.misc import print_metrics_table, dump_trained_model_configs
+from d2go.utils.misc import dump_trained_model_configs, print_metrics_table
 from detectron2.engine.defaults import create_ddp_model
 
 


### PR DESCRIPTION
Summary:
Applies new import merging and sorting from µsort v1.0.

When merging imports, µsort will make a best-effort to move associated
comments to match merged elements, but there are known limitations due to
the diynamic nature of Python and developer tooling. These changes should
not produce any dangerous runtime changes, but may require touch-ups to
satisfy linters and other tooling.

Note that µsort uses case-insensitive, lexicographical sorting, which
results in a different ordering compared to isort. This provides a more
consistent sorting order, matching the case-insensitive order used when
sorting import statements by module name, and ensures that "frog", "FROG",
and "Frog" always sort next to each other.

For details on µsort's sorting and merging semantics, see the user guide:
https://usort.readthedocs.io/en/stable/guide.html#sorting

Reviewed By: jreese

Differential Revision: D35559680

