### PR TITLE
apply import merging for fbcode/mobile-vision/d2go (1 of 4)

### DIFF
--- a/d2go/config/__init__.py
+++ b/d2go/config/__init__.py
@@ -4,10 +4,10 @@
 
 # forward the namespace to avoid `d2go.config.config`
 from .config import (
+    auto_scale_world_size,
+    CfgNode,
     CONFIG_CUSTOM_PARSE_REGISTRY,
     CONFIG_SCALING_METHOD_REGISTRY,
-    CfgNode,
-    auto_scale_world_size,
     reroute_config_path,
     temp_defrost,
 )

--- a/d2go/data/build.py
+++ b/d2go/data/build.py
@@ -5,7 +5,7 @@
 import itertools
 import logging
 import operator
-from collections import OrderedDict, defaultdict
+from collections import defaultdict, OrderedDict
 from typing import Dict
 
 import torch
@@ -19,7 +19,7 @@ from detectron2.data import (
     get_detection_dataset_dicts,
 )
 from detectron2.data.build import worker_init_reset_seed
-from detectron2.data.common import MapDataset, DatasetFromList
+from detectron2.data.common import DatasetFromList, MapDataset
 from detectron2.data.dataset_mapper import DatasetMapper
 from detectron2.data.samplers import RepeatFactorTrainingSampler
 from detectron2.utils.comm import get_world_size

--- a/d2go/data/dataset_mappers/__init__.py
+++ b/d2go/data/dataset_mappers/__init__.py
@@ -2,6 +2,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-from .build import D2GO_DATA_MAPPER_REGISTRY, build_dataset_mapper  # noqa
+from .build import build_dataset_mapper, D2GO_DATA_MAPPER_REGISTRY  # noqa
 from .d2go_dataset_mapper import D2GoDatasetMapper  # noqa
 from .rotated_dataset_mapper import RotatedDatasetMapper  # noqa

--- a/d2go/data/dataset_mappers/d2go_dataset_mapper_impl.py
+++ b/d2go/data/dataset_mappers/d2go_dataset_mapper_impl.py
@@ -13,10 +13,7 @@ from d2go.data.dataset_mappers.data_reading import (
 )
 from d2go.utils.helper import retryable
 from detectron2.data import detection_utils as utils, transforms as T
-from detectron2.data.transforms.augmentation import (
-    AugInput,
-    AugmentationList,
-)
+from detectron2.data.transforms.augmentation import AugInput, AugmentationList
 
 logger = logging.getLogger(__name__)
 

--- a/d2go/data/extended_coco.py
+++ b/d2go/data/extended_coco.py
@@ -7,7 +7,7 @@ import logging
 import shlex
 import subprocess
 from collections import defaultdict
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
 
 import detectron2.utils.comm as comm
 from detectron2.data import MetadataCatalog

--- a/d2go/data/extended_lvis.py
+++ b/d2go/data/extended_lvis.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     """
     import sys
 
-    import detectron2.data.datasets  # noqa # add pre-defined metadata
+    import detectron2.data.datasets  # noqa  # add pre-defined metadata
     import numpy as np
     from detectron2.utils.logger import setup_logger
     from detectron2.utils.visualizer import Visualizer

--- a/d2go/data/keypoint_metadata_registry.py
+++ b/d2go/data/keypoint_metadata_registry.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import NamedTuple, List, Tuple
+from typing import List, NamedTuple, Tuple
 
 from detectron2.utils.registry import Registry
 

--- a/d2go/data/transforms/affine.py
+++ b/d2go/data/transforms/affine.py
@@ -10,7 +10,7 @@ import cv2
 import numpy as np
 import torchvision.transforms as T
 from detectron2.config import CfgNode
-from detectron2.data.transforms import Transform, TransformGen, NoOpTransform
+from detectron2.data.transforms import NoOpTransform, Transform, TransformGen
 
 from .build import TRANSFORM_OP_REGISTRY
 

--- a/d2go/data/transforms/blur.py
+++ b/d2go/data/transforms/blur.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
 
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
 from detectron2.config import CfgNode
 from detectron2.data.transforms import NoOpTransform, Transform
 
-from .build import TRANSFORM_OP_REGISTRY, _json_load
+from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 class LocalizedBoxMotionBlurTransform(Transform):

--- a/d2go/data/transforms/box_utils.py
+++ b/d2go/data/transforms/box_utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import functools
-from typing import Tuple, List, Any, Union
+from typing import Any, List, Tuple, Union
 
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
@@ -11,7 +11,7 @@ from detectron2.config import CfgNode
 from detectron2.data.transforms.transform import Transform
 from detectron2.structures.boxes import Boxes
 
-from .build import TRANSFORM_OP_REGISTRY, _json_load
+from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 def get_box_union(boxes: Boxes):

--- a/d2go/data/transforms/build.py
+++ b/d2go/data/transforms/build.py
@@ -4,7 +4,7 @@
 
 import json
 import logging
-from typing import List, Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from detectron2.config import CfgNode
 from detectron2.data import transforms as d2T

--- a/d2go/data/transforms/color_yuv.py
+++ b/d2go/data/transforms/color_yuv.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-from typing import List, Callable, Union
+from typing import Callable, List, Union
 
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
@@ -11,7 +11,7 @@ from detectron2.data import detection_utils as du
 from detectron2.data.transforms.transform import Transform
 from fvcore.transforms.transform import BlendTransform
 
-from .build import TRANSFORM_OP_REGISTRY, _json_load
+from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 class InvertibleColorTransform(Transform):

--- a/d2go/data/transforms/crop.py
+++ b/d2go/data/transforms/crop.py
@@ -3,7 +3,7 @@
 
 
 import math
-from typing import List, Optional, Tuple, Union, Any
+from typing import Any, List, Optional, Tuple, Union
 
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
@@ -13,7 +13,7 @@ from detectron2.structures import BoxMode
 from fvcore.transforms.transform import CropTransform, NoOpTransform, Transform
 
 from . import box_utils as bu
-from .build import TRANSFORM_OP_REGISTRY, _json_load
+from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 class CropBoundary(aug.Augmentation):

--- a/d2go/data/transforms/d2_native.py
+++ b/d2go/data/transforms/d2_native.py
@@ -3,14 +3,14 @@
 
 
 import logging
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 import detectron2.data.transforms.augmentation as aug
 from detectron2.config import CfgNode
 from detectron2.data import transforms as d2T
 from detectron2.projects.point_rend import ColorAugSSDTransform
 
-from .build import TRANSFORM_OP_REGISTRY, _json_load
+from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 logger = logging.getLogger(__name__)
 

--- a/d2go/data/transforms/tensor.py
+++ b/d2go/data/transforms/tensor.py
@@ -2,11 +2,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-from typing import List, Optional, Union, Any
+from typing import Any, List, Optional, Union
 
 import numpy as np
 import torch
-from detectron2.data.transforms.augmentation import AugmentationList, Augmentation
+from detectron2.data.transforms.augmentation import Augmentation, AugmentationList
 from detectron2.structures import Boxes
 from fvcore.transforms.transform import Transform, TransformList
 

--- a/d2go/data/utils.py
+++ b/d2go/data/utils.py
@@ -17,10 +17,10 @@ import numpy as np
 import torch.utils.data as data
 from d2go.config import temp_defrost
 from d2go.data.datasets import (
-    register_dataset_split,
     ANN_FN,
     IM_DIR,
     INJECTED_COCO_DATASETS_LUT,
+    register_dataset_split,
 )
 from detectron2.data import DatasetCatalog, MetadataCatalog
 from detectron2.data.build import (

--- a/d2go/export/api.py
+++ b/d2go/export/api.py
@@ -26,7 +26,7 @@ import logging
 import os
 import sys
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, NamedTuple, Optional, Union, Tuple
+from typing import Callable, Dict, NamedTuple, Optional, Tuple, Union
 
 if sys.version_info >= (3, 8):
     from typing import final

--- a/d2go/export/torchscript.py
+++ b/d2go/export/torchscript.py
@@ -5,13 +5,13 @@
 import contextlib
 import logging
 import os
-from typing import Any, Tuple, Optional, Dict, NamedTuple, List, AnyStr, Set
+from typing import Any, AnyStr, Dict, List, NamedTuple, Optional, Set, Tuple
 
 import torch
-from d2go.export.api import ModelExportMethodRegistry, ModelExportMethod
+from d2go.export.api import ModelExportMethod, ModelExportMethodRegistry
 from detectron2.config.instantiate import dump_dataclass, instantiate
 from detectron2.export import dump_torchscript_IR
-from detectron2.export.flatten import TracingAdapter, flatten_to_tuple
+from detectron2.export.flatten import flatten_to_tuple, TracingAdapter
 from detectron2.export.torchscript_patch import patch_builtin_len
 from detectron2.utils.file_io import PathManager
 from mobile_cv.common.misc.file_utils import make_temp_directory

--- a/d2go/initializer.py
+++ b/d2go/initializer.py
@@ -41,13 +41,8 @@ def _register_d2_datasets():
 @_record_times(REGISTER_TIME)
 def _register():
     from d2go.data import dataset_mappers  # NOQA
-    from d2go.data.datasets import (
-        register_json_datasets,
-        register_builtin_datasets,
-    )
-    from d2go.modeling.backbone import (  # NOQA
-        fbnet_v2,
-    )
+    from d2go.data.datasets import register_builtin_datasets, register_json_datasets
+    from d2go.modeling.backbone import fbnet_v2  # NOQA
 
     # register_json_datasets()
     # register_builtin_datasets()

--- a/d2go/modeling/__init__.py
+++ b/d2go/modeling/__init__.py
@@ -3,9 +3,7 @@
 
 
 # NOTE: making necessary imports to register with Registery
-from . import backbone  # noqa
-from . import meta_arch  # noqa
-from . import modeldef  # noqa
+from . import backbone, meta_arch, modeldef  # noqa  # noqa  # noqa
 
 # namespace forwarding
 from .meta_arch.build import build_model

--- a/d2go/modeling/backbone/fbnet_v2.py
+++ b/d2go/modeling/backbone/fbnet_v2.py
@@ -12,10 +12,10 @@ import torch.nn as nn
 from d2go.modeling.modeldef.fbnet_modeldef_registry import FBNetV2ModelArch
 from detectron2.layers import ShapeSpec
 from detectron2.modeling import (
-    BACKBONE_REGISTRY,
-    RPN_HEAD_REGISTRY,
     Backbone,
+    BACKBONE_REGISTRY,
     build_anchor_generator,
+    RPN_HEAD_REGISTRY,
 )
 from detectron2.modeling.backbone.fpn import FPN, LastLevelMaxPool, LastLevelP6P7
 from detectron2.modeling.roi_heads import box_head, keypoint_head, mask_head
@@ -24,10 +24,10 @@ from mobile_cv.arch.fbnet_v2 import fbnet_builder as mbuilder
 from mobile_cv.arch.utils.helper import format_dict_expanding_list_values
 
 from .modules import (
+    KeypointRCNNConvUpsamplePredictorNoUpscale,
+    KeypointRCNNIRFPredictorNoUpscale,
     KeypointRCNNPredictor,
     KeypointRCNNPredictorNoUpscale,
-    KeypointRCNNIRFPredictorNoUpscale,
-    KeypointRCNNConvUpsamplePredictorNoUpscale,
     MaskRCNNConv1x1Predictor,
     RPNHeadConvRegressor,
 )

--- a/d2go/modeling/kmeans_anchors.py
+++ b/d2go/modeling/kmeans_anchors.py
@@ -8,7 +8,7 @@ from typing import List
 import detectron2.utils.comm as comm
 import numpy as np
 import torch
-from d2go.config import temp_defrost, CfgNode as CN
+from d2go.config import CfgNode as CN, temp_defrost
 from detectron2.engine import hooks
 from detectron2.layers import ShapeSpec
 from detectron2.modeling import GeneralizedRCNN

--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -16,13 +16,13 @@ from detectron2.projects.point_rend import PointRendMaskHead
 from detectron2.utils.registry import Registry
 from mobile_cv.arch.utils import fuse_utils
 from mobile_cv.arch.utils.quantize_utils import (
+    QuantWrapper,
     wrap_non_quant_group_norm,
     wrap_quant_subclass,
-    QuantWrapper,
 )
 from mobile_cv.predictor.api import FuncInfo
 from torch.ao.quantization import convert
-from torch.ao.quantization.quantize_fx import prepare_fx, prepare_qat_fx, convert_fx
+from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
 
 logger = logging.getLogger(__name__)
 

--- a/d2go/modeling/modeldef/modeldef.py
+++ b/d2go/modeling/modeldef/modeldef.py
@@ -5,7 +5,7 @@
 import copy
 
 from d2go.modeling.modeldef.fbnet_modeldef_registry import FBNetV2ModelArch
-from mobile_cv.arch.fbnet_v2.modeldef_utils import _ex, e1, e2, e1p, e3, e4, e6
+from mobile_cv.arch.fbnet_v2.modeldef_utils import _ex, e1, e1p, e2, e3, e4, e6
 
 
 def _mutated_tuple(tp, pos, value):

--- a/d2go/modeling/quantization.py
+++ b/d2go/modeling/quantization.py
@@ -11,8 +11,7 @@ import d2go.utils.qat_utils as qat_utils
 import detectron2.utils.comm as comm
 import torch
 from detectron2.checkpoint import DetectionCheckpointer
-from detectron2.engine import HookBase
-from detectron2.engine import SimpleTrainer
+from detectron2.engine import HookBase, SimpleTrainer
 from mobile_cv.arch.quantization.observer import update_stat as observer_update_stat
 from mobile_cv.arch.utils import fuse_utils
 from mobile_cv.common.misc.iter_utils import recursive_iterate

--- a/d2go/modeling/subclass.py
+++ b/d2go/modeling/subclass.py
@@ -8,10 +8,7 @@ from typing import Any, Dict, List
 import numpy as np
 import torch
 from d2go.config import CfgNode as CN
-from d2go.data.dataset_mappers import (
-    D2GO_DATA_MAPPER_REGISTRY,
-    D2GoDatasetMapper,
-)
+from d2go.data.dataset_mappers import D2GO_DATA_MAPPER_REGISTRY, D2GoDatasetMapper
 from d2go.utils.helper import alias
 from detectron2.layers import cat
 from detectron2.modeling import ROI_HEADS_REGISTRY, StandardROIHeads

--- a/d2go/runner/__init__.py
+++ b/d2go/runner/__init__.py
@@ -3,7 +3,7 @@
 
 
 import importlib
-from typing import Type, Union, Optional
+from typing import Optional, Type, Union
 
 from .default_runner import (
     BaseRunner,

--- a/d2go/runner/callbacks/quantization.py
+++ b/d2go/runner/callbacks/quantization.py
@@ -4,7 +4,7 @@ from abc import ABC
 from copy import deepcopy
 from dataclasses import dataclass
 from types import MethodType
-from typing import Any, Callable, Dict, List, Set, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 from d2go.config import CfgNode
@@ -14,11 +14,11 @@ from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.utilities import rank_zero_info
 from torch.ao.quantization import (  # @manual
+    get_default_qat_qconfig,
+    get_default_qconfig,
     QConfig,
     QConfigDynamic,
     QuantType,
-    get_default_qat_qconfig,
-    get_default_qconfig,
 )
 from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
 from torch.ao.quantization.utils import get_quant_type

--- a/d2go/runner/lightning_task.py
+++ b/d2go/runner/lightning_task.py
@@ -13,14 +13,10 @@ import torch
 from d2go.config import CfgNode
 from d2go.data.build import build_d2go_train_loader
 from d2go.data.datasets import inject_coco_datasets, register_dynamic_datasets
-from d2go.data.utils import (
-    update_cfg_if_using_adhoc_dataset,
-)
+from d2go.data.utils import update_cfg_if_using_adhoc_dataset
 from d2go.export.d2_meta_arch import patch_d2_meta_arch
 from d2go.modeling import build_model
-from d2go.modeling.model_freezing_utils import (
-    set_requires_grad,
-)
+from d2go.modeling.model_freezing_utils import set_requires_grad
 from d2go.modeling.quantization import (
     default_prepare_for_quant,
     default_prepare_for_quant_convert,
@@ -28,9 +24,9 @@ from d2go.modeling.quantization import (
 from d2go.optimizer import build_optimizer_mapper
 from d2go.runner.callbacks.quantization import maybe_prepare_for_quantization, PREPARED
 from d2go.runner.default_runner import (
+    _get_tbx_writer,
     Detectron2GoRunner,
     GeneralizedRCNNRunner,
-    _get_tbx_writer,
 )
 from d2go.utils.ema_state import EMAState
 from d2go.utils.misc import get_tensorboard_log_dir
@@ -39,7 +35,7 @@ from detectron2.solver import (
     build_lr_scheduler as d2_build_lr_scheduler,
     build_optimizer as d2_build_optimizer,
 )
-from pytorch_lightning.utilities import rank_zero_only, rank_zero_info
+from pytorch_lightning.utilities import rank_zero_info, rank_zero_only
 from pytorch_lightning.utilities.logger import _flatten_dict
 
 _STATE_DICT_KEY = "state_dict"

--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -10,8 +10,8 @@ import time
 import detectron2.utils.comm as comm
 import torch
 from d2go.config import (
-    CfgNode as CN,
     auto_scale_world_size,
+    CfgNode as CN,
     reroute_config_path,
     temp_defrost,
 )

--- a/d2go/utils/flop_calculator.py
+++ b/d2go/utils/flop_calculator.py
@@ -13,7 +13,7 @@ from d2go.utils.helper import run_once
 from detectron2.utils.analysis import FlopCountAnalysis
 from detectron2.utils.file_io import PathManager
 from detectron2.utils.registry import Registry
-from fvcore.nn import flop_count_table, flop_count_str
+from fvcore.nn import flop_count_str, flop_count_table
 
 
 PROFILER_REGISTRY = Registry("PROFILER")

--- a/d2go/utils/get_default_cfg.py
+++ b/d2go/utils/get_default_cfg.py
@@ -2,8 +2,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from d2go.config import CfgNode as CN
 from d2go.data.build import (
-    add_weighted_training_sampler_default_configs,
     add_random_subset_training_sampler_default_configs,
+    add_weighted_training_sampler_default_configs,
 )
 from d2go.data.config import add_d2go_data_default_configs
 from d2go.modeling import kmeans_anchors, model_ema

--- a/d2go/utils/helper.py
+++ b/d2go/utils/helper.py
@@ -19,8 +19,7 @@ import typing
 import warnings
 import zipfile
 from contextlib import contextmanager
-from functools import partial
-from functools import wraps
+from functools import partial, wraps
 from random import random
 from typing import (
     Any,
@@ -44,9 +43,9 @@ from detectron2.checkpoint import DetectionCheckpointer
 from detectron2.config import get_cfg
 from detectron2.data import MetadataCatalog
 from detectron2.engine import (
-    DefaultTrainer,
     default_argument_parser,
     default_setup,
+    DefaultTrainer,
     hooks,
     launch,
 )

--- a/d2go/utils/testing/meta_arch_helper.py
+++ b/d2go/utils/testing/meta_arch_helper.py
@@ -6,7 +6,7 @@ import torch
 from d2go.utils.testing.data_loader_helper import create_local_dataset
 from detectron2.modeling import META_ARCH_REGISTRY
 from detectron2.structures import Boxes, ImageList, Instances
-from torch.ao.quantization.quantize_fx import prepare_qat_fx, convert_fx
+from torch.ao.quantization.quantize_fx import convert_fx, prepare_qat_fx
 
 
 @META_ARCH_REGISTRY.register()

--- a/d2go/utils/testing/rcnn_helper.py
+++ b/d2go/utils/testing/rcnn_helper.py
@@ -15,10 +15,7 @@ from d2go.runner import GeneralizedRCNNRunner
 from d2go.utils.testing.data_loader_helper import (
     create_detection_data_loader_on_toy_dataset,
 )
-from detectron2.structures import (
-    Boxes,
-    Instances,
-)
+from detectron2.structures import Boxes, Instances
 from detectron2.utils.testing import assert_instances_allclose
 from mobile_cv.predictor.api import create_predictor
 from parameterized import parameterized

--- a/d2go/utils/visualization.py
+++ b/d2go/utils/visualization.py
@@ -2,9 +2,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-from typing import Type, Optional
+from typing import Optional, Type
 
-from detectron2.data import DatasetCatalog, MetadataCatalog, detection_utils as utils
+from detectron2.data import DatasetCatalog, detection_utils as utils, MetadataCatalog
 from detectron2.evaluation import DatasetEvaluator
 from detectron2.modeling import META_ARCH_REGISTRY
 from detectron2.utils.events import get_event_storage

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from os import path
 from typing import List
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
Summary:
Applies new import merging and sorting from µsort v1.0.

When merging imports, µsort will make a best-effort to move associated
comments to match merged elements, but there are known limitations due to
the diynamic nature of Python and developer tooling. These changes should
not produce any dangerous runtime changes, but may require touch-ups to
satisfy linters and other tooling.

Note that µsort uses case-insensitive, lexicographical sorting, which
results in a different ordering compared to isort. This provides a more
consistent sorting order, matching the case-insensitive order used when
sorting import statements by module name, and ensures that "frog", "FROG",
and "Frog" always sort next to each other.

For details on µsort's sorting and merging semantics, see the user guide:
https://usort.readthedocs.io/en/stable/guide.html#sorting

Reviewed By: jreese

Differential Revision: D35559658

