### PR TITLE
Make OSS helper fb_overwrite into separate file and independent of other components

### DIFF
--- a/d2go/data/build.py
+++ b/d2go/data/build.py
@@ -12,7 +12,7 @@ import torch
 from d2go.config import CfgNode
 from d2go.data.dataset_mappers import build_dataset_mapper
 from d2go.data.utils import ClipLengthGroupedDataset
-from d2go.utils.misc import fb_overwritable
+from d2go.utils.oss_helper import fb_overwritable
 from detectron2.data import (
     build_batch_data_loader,
     build_detection_train_loader,

--- a/d2go/data/datasets.py
+++ b/d2go/data/datasets.py
@@ -9,7 +9,7 @@ import os
 from collections import namedtuple
 
 from d2go.utils.helper import get_dir_path
-from d2go.utils.misc import fb_overwritable
+from d2go.utils.oss_helper import fb_overwritable
 from detectron2.data import DatasetCatalog, MetadataCatalog
 from detectron2.utils.registry import Registry
 

--- a/d2go/utils/misc.py
+++ b/d2go/utils/misc.py
@@ -8,11 +8,11 @@ import warnings
 from contextlib import contextmanager
 from typing import Dict, Iterator
 
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 import detectron2.utils.comm as comm
 import torch
 from d2go.config import CfgNode
 from detectron2.utils.file_io import PathManager
-from mobile_cv.common.misc.py import dynamic_import
 from tabulate import tabulate
 
 from .tensorboard_log_util import get_tensorboard_log_dir  # noqa: forwarding
@@ -112,24 +112,3 @@ def _log_api_usage(identifier: str):
     inside facebook's infra.
     """
     torch._C._log_api_usage_once("d2go." + identifier)
-
-
-def fb_overwritable():
-    """Decorator on function that has alternative internal implementation"""
-    try:
-        import d2go.infra.fb  # NOQA
-
-        is_oss = False
-    except ImportError:
-        is_oss = True
-
-    def deco(oss_func):
-        if is_oss:
-            return oss_func
-        else:
-            oss_module = oss_func.__module__
-            fb_module = oss_module + "_fb"  # xxx.py -> xxx_fb.py
-            fb_func = dynamic_import("{}.{}".format(fb_module, oss_func.__name__))
-            return fb_func
-
-    return deco

--- a/d2go/utils/oss_helper.py
+++ b/d2go/utils/oss_helper.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from mobile_cv.common.misc.py import dynamic_import
+
+
+def fb_overwritable():
+    """Decorator on function that has alternative internal implementation"""
+    try:
+        import d2go.utils.fb.open_source_canary  # noqa
+
+        is_oss = False
+    except ImportError:
+        is_oss = True
+
+    def deco(oss_func):
+        if is_oss:
+            return oss_func
+        else:
+            oss_module = oss_func.__module__
+            fb_module = oss_module + "_fb"  # xxx.py -> xxx_fb.py
+            fb_func = dynamic_import("{}.{}".format(fb_module, oss_func.__name__))
+            return fb_func
+
+    return deco


### PR DESCRIPTION
Summary:
*This diff is part of a stack which has the goal of "buckifying" D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go core and enabling autodeps and other tooling. The last diff in the stack introduces the TARGETS. The diffs earlier in the stack are resolving circular dependencies and other issues which prevent the buckification from occurring.*

The current function for detecting OSS has two issues. It is mixed with other utils, which often causes circular dependencies, and it is using fb.infra.env which depends on other components, also introducing circular buck dependencies.

This diff changes it to be in a separate file, and to make it use an empty "canary" file, which will be present in FB builds, but not present in OSS builds.

Differential Revision: D35928340

