### PR TITLE
Move files from OSS option 1 to Option 2

### DIFF
--- a/d2go/config/utils.py
+++ b/d2go/config/utils.py
@@ -2,11 +2,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import os
-from typing import Dict, List
+from enum import Enum
+from typing import Any, Dict, List
 
 import pkg_resources
+from d2go.utils.oss_helper import fb_overwritable
 
 
+@fb_overwritable()
 def reroute_config_path(path: str) -> str:
     """
     Supporting rerouting the config files for convenience:
@@ -187,3 +190,15 @@ def get_diff_cfg(old_cfg, new_cfg):
 
     out = new_cfg.__class__()
     return get_diff_cfg_rec(old_cfg, new_cfg, out)
+
+
+def namedtuple_to_dict(obj: Any):
+    """Convert NamedTuple or dataclass to dict so it can be used as config"""
+    res = {}
+    for k, v in obj.__dict__.items():
+        if isinstance(v, Enum):
+            # in case of enum, serialize the enum value
+            res[k] = v.value
+        else:
+            res[k] = v
+    return res

--- a/d2go/data/build.py
+++ b/d2go/data/build.py
@@ -12,7 +12,7 @@ import torch
 from d2go.config import CfgNode
 from d2go.data.dataset_mappers import build_dataset_mapper
 from d2go.data.utils import ClipLengthGroupedDataset
-from d2go.utils.misc import fb_overwritable
+from d2go.utils.oss_helper import fb_overwritable
 from detectron2.data import (
     build_batch_data_loader,
     build_detection_train_loader,

--- a/d2go/data/datasets.py
+++ b/d2go/data/datasets.py
@@ -9,7 +9,7 @@ import os
 from collections import namedtuple
 
 from d2go.utils.helper import get_dir_path
-from d2go.utils.misc import fb_overwritable
+from d2go.utils.oss_helper import fb_overwritable
 from detectron2.data import DatasetCatalog, MetadataCatalog
 from detectron2.utils.registry import Registry
 

--- a/d2go/utils/get_default_cfg.py
+++ b/d2go/utils/get_default_cfg.py
@@ -12,8 +12,10 @@ from d2go.modeling.meta_arch.fcos import add_fcos_configs
 from d2go.modeling.model_freezing_utils import add_model_freezing_configs
 from d2go.modeling.subclass import add_subclass_configs
 from d2go.quantization.modeling import add_quantization_default_configs
+from d2go.utils.oss_helper import fb_overwritable
 
 
+@fb_overwritable()
 def add_tensorboard_default_configs(_C):
     _C.TENSORBOARD = CN()
     # Output from dataloader will be written to tensorboard at this frequency
@@ -28,12 +30,14 @@ def add_tensorboard_default_configs(_C):
     _C.register_deprecated_key("TENSORBOARD.LOG_DIR")
 
 
+@fb_overwritable()
 def add_abnormal_checker_configs(_C):
     _C.ABNORMAL_CHECKER = CN()
     # check and log the iteration with bad losses if enabled
     _C.ABNORMAL_CHECKER.ENABLED = False
 
 
+@fb_overwritable()
 def get_default_cfg(_C):
     # _C.MODEL.FBNET...
     add_fbnet_v2_default_configs(_C)

--- a/d2go/utils/misc.py
+++ b/d2go/utils/misc.py
@@ -8,11 +8,11 @@ import warnings
 from contextlib import contextmanager
 from typing import Dict, Iterator
 
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 import detectron2.utils.comm as comm
 import torch
 from d2go.config import CfgNode
 from detectron2.utils.file_io import PathManager
-from mobile_cv.common.misc.py import dynamic_import
 from tabulate import tabulate
 
 from .tensorboard_log_util import get_tensorboard_log_dir  # noqa: forwarding
@@ -112,24 +112,3 @@ def _log_api_usage(identifier: str):
     inside facebook's infra.
     """
     torch._C._log_api_usage_once("d2go." + identifier)
-
-
-def fb_overwritable():
-    """Decorator on function that has alternative internal implementation"""
-    try:
-        import d2go.infra.fb  # NOQA
-
-        is_oss = False
-    except ImportError:
-        is_oss = True
-
-    def deco(oss_func):
-        if is_oss:
-            return oss_func
-        else:
-            oss_module = oss_func.__module__
-            fb_module = oss_module + "_fb"  # xxx.py -> xxx_fb.py
-            fb_func = dynamic_import("{}.{}".format(fb_module, oss_func.__name__))
-            return fb_func
-
-    return deco

--- a/d2go/utils/oss_helper.py
+++ b/d2go/utils/oss_helper.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from mobile_cv.common.misc.py import dynamic_import
+
+
+def fb_overwritable():
+    """Decorator on function that has alternative internal implementation"""
+    try:
+        import d2go.utils.fb.open_source_canary  # noqa
+
+        is_oss = False
+    except ImportError:
+        is_oss = True
+
+    def deco(oss_func):
+        if is_oss:
+            return oss_func
+        else:
+            oss_module = oss_func.__module__
+            fb_module = oss_module + "_fb"  # xxx.py -> xxx_fb.py
+            fb_func = dynamic_import("{}.{}".format(fb_module, oss_func.__name__))
+            return fb_func
+
+    return deco


### PR DESCRIPTION
Summary:
*This diff is part of a stack which has the goal of "buckifying" D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go core and enabling autodeps and other tooling. The last diff in the stack introduces the TARGETS. The diffs earlier in the stack are resolving circular dependencies and other issues which prevent the buckification from occurring.*

This diffs moves a few files from using the pattern 1 of open source overriding to the pattern 2, using the decorators.

Differential Revision: D35928506

