### PR TITLE
Refactor registry and setup backend to separate file

### DIFF
--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -40,6 +40,7 @@ class GeneralizedRCNNPatch:
         "prepare_for_export",
         "prepare_for_quant",
         "prepare_for_quant_convert",
+        "_cast_model_to_device",
     ]
 
     def prepare_for_export(self, cfg, *args, **kwargs):
@@ -55,6 +56,9 @@ class GeneralizedRCNNPatch:
             cfg.RCNN_PREPARE_FOR_QUANT_CONVERT
         )
         return func(self, cfg, *args, **kwargs)
+
+    def _cast_model_to_device(self, device):
+        return _cast_detection_model(self, device)
 
 
 @RCNN_PREPARE_FOR_EXPORT_REGISTRY.register()

--- a/d2go/quantization/modeling.py
+++ b/d2go/quantization/modeling.py
@@ -139,11 +139,17 @@ def add_quantization_default_configs(_C):
 # TODO: model.to(device) might not work for detection meta-arch, this function is the
 # workaround, in general, we might need a meta-arch API for this if needed.
 def _cast_model_to_device(model, device):
-    from d2go.modeling.meta_arch.rcnn import _cast_detection_model
-    from detectron2.modeling import GeneralizedRCNN
-
-    assert isinstance(model, GeneralizedRCNN), "Currently only availabe for RCNN"
-    return _cast_detection_model(model, device)
+    if hasattr(
+        model, "_cast_model_to_device"
+    ):  # we can make this formal by removing "_"
+        return model._cast_model_to_device(device)
+    else:
+        logger.warning(
+            "model.to(device) doesn't guarentee moving the entire model, "
+            "if customization is needed, please implement _cast_model_to_device "
+            "for the MetaArch"
+        )
+        return model.to(device)
 
 
 def add_d2_quant_mapping(mappings):

--- a/d2go/runner/__init__.py
+++ b/d2go/runner/__init__.py
@@ -5,13 +5,9 @@
 import importlib
 from typing import Optional, Type, Union
 
-from .default_runner import (
-    BaseRunner,
-    Detectron2GoRunner,
-    GeneralizedRCNNRunner,
-    TRAINER_HOOKS_REGISTRY,
-)
+from .default_runner import BaseRunner, Detectron2GoRunner, GeneralizedRCNNRunner
 from .lightning_task import DefaultTask
+from .training_hooks import TRAINER_HOOKS_REGISTRY
 
 
 __all__ = [

--- a/d2go/runner/training_hooks.py
+++ b/d2go/runner/training_hooks.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import logging
+from typing import List
+
+from detectron2.engine import HookBase
+from detectron2.utils.registry import Registry
+
+logger = logging.getLogger(__name__)
+
+# List of functions to add hooks for trainer, all functions in the registry will
+# be called to add hooks
+#   func(hooks: List[HookBase]) -> None
+TRAINER_HOOKS_REGISTRY = Registry("TRAINER_HOOKS_REGISTRY")
+
+
+def update_hooks_from_registry(hooks: List[HookBase]):
+    for name, hook_func in TRAINER_HOOKS_REGISTRY:
+        logger.info(f"Update trainer hooks from {name}...")
+        hook_func(hooks)

--- a/tests/runner/test_runner_default_runner.py
+++ b/tests/runner/test_runner_default_runner.py
@@ -10,6 +10,7 @@ import unittest
 import d2go.runner.default_runner as default_runner
 import torch
 from d2go.runner import create_runner
+from d2go.runner.training_hooks import TRAINER_HOOKS_REGISTRY
 from d2go.utils.testing import helper
 from d2go.utils.testing.data_loader_helper import create_local_dataset
 from detectron2.evaluation import COCOEvaluator, RotatedCOCOEvaluator
@@ -353,7 +354,7 @@ class TestDefaultRunner(unittest.TestCase):
     def test_d2go_runner_trainer_hooks(self):
         counts = 0
 
-        @default_runner.TRAINER_HOOKS_REGISTRY.register()
+        @TRAINER_HOOKS_REGISTRY.register()
         def _check_hook_func(hooks):
             nonlocal counts
             counts = len(hooks)


### PR DESCRIPTION
Summary:
*This diff is part of a stack which has the goal of "buckifying" D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go core and enabling autodeps and other tooling. The last diff in the stack introduces the TARGETS. The diffs earlier in the stack are resolving circular dependencies and other issues which prevent the buckification from occurring.*

Again, a circular dependency between quantization/modeling -> meta_arch->rcnn. Solved in a similar way, they are caused by functions which only interact with the global registry. Separate the cause of the circular dependency into its own file, which will later have a separate TARGET.

Differential Revision: D35966052

