### PR TITLE
Fix a bug in export api that prevents setting specific kwargs for different backends

### DIFF
--- a/d2go/export/torchscript.py
+++ b/d2go/export/torchscript.py
@@ -405,8 +405,18 @@ class DefaultTorchscriptExport(ModelExportMethod):
         export_method: Optional[str],
         **export_kwargs,
     ):
+        expected_arguments = {
+            "jit_mode",
+            "torchscript_filename",
+            "mobile_optimization",
+            "_extra_files",
+        }
+        filtered_kwargs = {
+            k: v for k, v in export_kwargs.items() if k in expected_arguments
+        }
+
         torchscript_filename = export_optimize_and_save_torchscript(
-            model, input_args, save_path, **export_kwargs
+            model, input_args, save_path, **filtered_kwargs
         )
         return {TORCHSCRIPT_FILENAME_KEY: torchscript_filename}
 


### PR DESCRIPTION
Summary:
When exporting the model to different backend engines, users may set the `model_export_kwargs` for different backends.

The torchscript backend needs a placeholder `**export_kwargs` to allow the kwargs for other backends.

Frankly speaking, this mechanism of passing the same set of kwargs to different backends is confusing. Better to be refactored to the factory pattern with isolated kwargs.

Differential Revision: D36140771

