### PR TITLE
Buckify d2go/core

### DIFF
--- a/d2go/data/dataset_mappers/d2go_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/d2go_dataset_mapper.py
@@ -7,6 +7,7 @@ import logging
 
 import numpy as np
 import torch
+from d2go.data.dataset_mappers.build import D2GO_DATA_MAPPER_REGISTRY
 from d2go.data.dataset_mappers.data_reading import (
     read_image_with_prefetch,
     read_sem_seg_file_with_prefetch,
@@ -14,8 +15,6 @@ from d2go.data.dataset_mappers.data_reading import (
 from d2go.utils.helper import retryable
 from detectron2.data import detection_utils as utils, transforms as T
 from detectron2.data.transforms.augmentation import AugInput, AugmentationList
-
-from .build import D2GO_DATA_MAPPER_REGISTRY
 
 logger = logging.getLogger(__name__)
 

--- a/d2go/data/dataset_mappers/rotated_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/rotated_dataset_mapper.py
@@ -7,11 +7,11 @@ import logging
 
 import numpy as np
 import torch
-from d2go.data.dataset_mappers.d2go_dataset_mapper import D2GoDatasetMapper
 from detectron2.data import detection_utils as utils, transforms as T
 from detectron2.structures import BoxMode, Instances, RotatedBoxes
 
 from .build import D2GO_DATA_MAPPER_REGISTRY
+from .d2go_dataset_mapper import D2GoDatasetMapper
 
 
 logger = logging.getLogger(__name__)

--- a/d2go/data/transforms/affine.py
+++ b/d2go/data/transforms/affine.py
@@ -10,6 +10,8 @@ import cv2
 import numpy as np
 import torchvision.transforms as T
 from detectron2.config import CfgNode
+
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 from detectron2.data.transforms import NoOpTransform, Transform, TransformGen
 
 from .build import TRANSFORM_OP_REGISTRY

--- a/d2go/data/transforms/blur.py
+++ b/d2go/data/transforms/blur.py
@@ -3,9 +3,12 @@
 
 from typing import Dict, List, Tuple
 
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
 from detectron2.config import CfgNode
+
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 from detectron2.data.transforms import NoOpTransform, Transform
 
 from .build import _json_load, TRANSFORM_OP_REGISTRY

--- a/d2go/data/transforms/crop.py
+++ b/d2go/data/transforms/crop.py
@@ -8,6 +8,8 @@ from typing import Any, List, Optional, Tuple, Union
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
 from detectron2.config import CfgNode
+
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 from detectron2.data.transforms import ExtentTransform
 from detectron2.structures import BoxMode
 from fvcore.transforms.transform import CropTransform, NoOpTransform, Transform

--- a/d2go/export/api.py
+++ b/d2go/export/api.py
@@ -3,7 +3,7 @@
 import json
 import sys
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, NamedTuple, Optional, Union
+from typing import Callable, Dict, NamedTuple, Optional, Tuple, Union
 
 import torch.nn as nn
 from mobile_cv.common.misc.file_utils import make_temp_directory

--- a/d2go/export/exporter.py
+++ b/d2go/export/exporter.py
@@ -37,10 +37,16 @@ from mobile_cv.predictor.api import ModelInfo, PredictorInfo
 
 TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
 if TORCH_VERSION > (1, 10):
+    # @manual=//caffe2:torch
     from torch.ao.quantization import convert
+
+    # @manual=//caffe2:torch
     from torch.ao.quantization.quantize_fx import convert_fx
 else:
+    # @manual=//caffe2:torch
     from torch.quantization import convert
+
+    # @manual=//caffe2:torch
     from torch.quantization.quantize_fx import convert_fx
 
 logger = logging.getLogger(__name__)

--- a/d2go/export/torchscript.py
+++ b/d2go/export/torchscript.py
@@ -17,6 +17,8 @@ from detectron2.utils.file_io import PathManager
 from mobile_cv.common.misc.file_utils import make_temp_directory
 from mobile_cv.common.misc.iter_utils import recursive_iterate
 from torch import nn
+
+# @manual="//caffe2:torch",
 from torch._C import MobileOptimizerType
 from torch.utils.bundled_inputs import augment_model_with_bundled_inputs
 from torch.utils.mobile_optimizer import optimize_for_mobile

--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -25,6 +25,8 @@ from mobile_cv.arch.utils.quantize_utils import (
     wrap_quant_subclass,
 )
 from mobile_cv.predictor.api import FuncInfo
+
+# @manual=//caffe2:torch
 from torch.ao.quantization import convert
 from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
 

--- a/d2go/quantization/modeling.py
+++ b/d2go/quantization/modeling.py
@@ -11,6 +11,8 @@ import detectron2.utils.comm as comm
 import torch
 from d2go.quantization import learnable_qat
 from detectron2.checkpoint import DetectionCheckpointer
+
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 from detectron2.engine import HookBase, SimpleTrainer
 from mobile_cv.arch.quantization.observer import update_stat as observer_update_stat
 from mobile_cv.arch.utils import fuse_utils

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -39,6 +39,8 @@ from detectron2.data import (
     build_detection_train_loader as d2_build_detection_train_loader,
     MetadataCatalog,
 )
+
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 from detectron2.engine import AMPTrainer, hooks, SimpleTrainer
 from detectron2.evaluation import (
     COCOEvaluator,

--- a/d2go/runner/training_hooks.py
+++ b/d2go/runner/training_hooks.py
@@ -3,6 +3,7 @@
 import logging
 from typing import List
 
+# @manual=//vision/fair/detectron2/detectron2:detectron2
 from detectron2.engine import HookBase
 from detectron2.utils.registry import Registry
 

--- a/d2go/utils/helper.py
+++ b/d2go/utils/helper.py
@@ -42,13 +42,9 @@ import torch
 from detectron2.checkpoint import DetectionCheckpointer
 from detectron2.config import get_cfg
 from detectron2.data import MetadataCatalog
-from detectron2.engine import (
-    default_argument_parser,
-    default_setup,
-    DefaultTrainer,
-    hooks,
-    launch,
-)
+
+# @manual=//vision/fair/detectron2/detectron2:detectron2
+from detectron2.engine import DefaultTrainer, hooks, launch
 from detectron2.evaluation import (
     CityscapesInstanceEvaluator,
     CityscapesSemSegEvaluator,
@@ -60,6 +56,7 @@ from detectron2.evaluation import (
     SemSegEvaluator,
     verify_results,
 )
+from detectron2.utils.events import TensorboardXWriter
 from mobile_cv.common.misc.oss_utils import fb_overwritable
 
 T = TypeVar("T")
@@ -68,8 +65,6 @@ FuncType = Callable[..., Any]
 F = TypeVar("F", bound=FuncType)
 RT = TypeVar("RT")
 NT = TypeVar("T", bound=NamedTuple)
-
-from detectron2.utils.events import TensorboardXWriter
 
 
 class MultipleFunctionCallError(Exception):


### PR DESCRIPTION
Summary:
*This diff is part of a stack which has the goal of "buckifying" D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go core and enabling autodeps and other tooling. The last diff in the stack introduces the TARGETS. The diffs earlier in the stack are resolving circular dependencies and other issues which prevent the buckification from occurring.*

This diff adds all the TARGETS in the d2go core code so that we can enable autodeps. The top-level //mobile-vision/d2go/d2go:d2go dependency does not change behaviour, it is not affected by autodeps and contains all the added dependencies in the folder.

Buck build works:
```
[jmiquel@devvm1250.ash0 ~/fbsource/fbcode] buck build //mobile-vision/d2go/d2go:d2go
Parsing buck files: finished in 1.9 sec
Building: finished in 5.5 sec (100%) 20178/22161 jobs, 0/22161 updated
  Total time: 7.4 sec
More details at https://www.internalfb.com/intern/buck/build/37e4cd54-e17a-42be-b4df-9212ee0f918e
BUILD SUCCEEDED
```

Differential Revision: D35896841

