### PR TITLE
Enable torch tracing by changing assertions in d2go forwards to allow for torch.fx.proxy.Proxy type.

### DIFF
--- a/d2go/modeling/backbone/modules.py
+++ b/d2go/modeling/backbone/modules.py
@@ -7,6 +7,7 @@ from typing import List
 import torch
 import torch.nn as nn
 from detectron2 import layers
+from detectron2.utils.tracing import assert_fx_safe
 from mobile_cv.arch.fbnet_v2.irf_block import IRFBlock
 
 
@@ -33,7 +34,7 @@ class RPNHeadConvRegressor(nn.Module):
             torch.nn.init.constant_(l.bias, 0)
 
     def forward(self, x: List[torch.Tensor]):
-        assert isinstance(x, (list, tuple))
+        assert_fx_safe(isinstance(x, (list, tuple)), "Unexpected data type")
         logits = [self.cls_logits(y) for y in x]
         bbox_reg = [self.bbox_pred(y) for y in x]
 


### PR DESCRIPTION
Summary:
Torch FX tracing propagates a type of `torch.fx.proxy.Proxy` through the graph.

Existing type assertions in the d2go code base trigger during torch FX tracing, causing tracing to fail.

This diff adds a helper function `is_fx_proxy()`, for checking for `torch.fx.proxy.Proxy` instances, then uses this to guard the existing assertions, thus enabling the tracing, as well as maintaining the originally intended functionality.

Differential Revision: D35518556

