### PR TITLE
On-the-fly evaluation during training

### DIFF
--- a/d2go/data/transforms/crop.py
+++ b/d2go/data/transforms/crop.py
@@ -227,7 +227,9 @@ class RandomInstanceCrop(aug.Augmentation):
         bbox_xywh = bu.scale_bbox_center(bbox_xywh, scale)
         bbox_xywh = bu.clip_box_xywh(bbox_xywh, image_size).int()
 
-        return CropTransform(*bbox_xywh.tolist())
+        return CropTransform(
+            *bbox_xywh.tolist(), orig_h=image_size[0], orig_w=image_size[1]
+        )
 
 
 # example repr: "RandomInstanceCropOp::{'crop_scale': [0.8, 1.6]}"


### PR DESCRIPTION
Summary:
Currently we do not have quantitative evaluation during multitask joint training.  It is necessary if EMA is turned on to choose the best model. We implement an instance-level on-the-fly evaluation to enable choosing the best EMA model during training.

- Map predictions on cropped image to the original image using inverse transforms
- Support visualization of the prediction on original images
- Transform prediction on cropped image to original image can be turned on by setting ``MULTITASK.JOINT_TRAIN.POST_TRANSFORM=True``
- (minor) add ``orig_h`` and ``orig_w`` to ``CropTransform`` so we can use inverse transform

Differential Revision: D36268572

