### PR TITLE
Add orig_h and orig_w to CropTransform to enable inverse transform

### DIFF
--- a/d2go/data/transforms/crop.py
+++ b/d2go/data/transforms/crop.py
@@ -227,7 +227,9 @@ class RandomInstanceCrop(aug.Augmentation):
         bbox_xywh = bu.scale_bbox_center(bbox_xywh, scale)
         bbox_xywh = bu.clip_box_xywh(bbox_xywh, image_size).int()
 
-        return CropTransform(*bbox_xywh.tolist())
+        return CropTransform(
+            *bbox_xywh.tolist(), orig_h=image_size[0], orig_w=image_size[1]
+        )
 
 
 # example repr: "RandomInstanceCropOp::{'crop_scale': [0.8, 1.6]}"


### PR DESCRIPTION
Summary: Inverse transform of ``CropTransform`` requires knowing the original h and w. Add ``orig_h`` and ``orig_w`` to ``CropTransform`` so inverse transform can be used.

Differential Revision: D36321451

