### PR TITLE
revert the runner change in D36632783

### DIFF
--- a/d2go/data/extended_coco.py
+++ b/d2go/data/extended_coco.py
@@ -336,7 +336,7 @@ def coco_text_load(
     archive_file: Optional[str] = None,
 ) -> List[Dict]:
     if archive_file is not None:
-        if comm.get_rank() == 0:
+        if comm.get_local_rank() == 0:
             extract_archive_file(archive_file, image_root)
         comm.synchronize()
 

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -325,8 +325,6 @@ class Detectron2GoRunner(BaseRunner):
 
             # NOTE: creating evaluator after dataset is loaded as there might be dependency.  # noqa
             data_loader = self.build_detection_test_loader(cfg, dataset_name)
-            # Synchronize to ensure data processing during data loader build is complete
-            comm.synchronize()
 
             evaluator = self.get_evaluator(
                 cfg, dataset_name, output_folder=output_folder


### PR DESCRIPTION
Summary: synchronization should be handled inside creating data loader, otherwise we need to add synchronization everywhere besides the training-loop, which is impossible.

Differential Revision: D36683362

