### PR TITLE
Add transform information in dataset_dict

### DIFF
--- a/d2go/data/dataset_mappers/d2go_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/d2go_dataset_mapper.py
@@ -117,6 +117,7 @@ class D2GoDatasetMapper(object):
             if self.crop_gen:
                 transforms = crop_tfm + transforms
 
+        dataset_dict["transforms"] = transforms
         image_shape = image.shape[:2]  # h, w
         if image.ndim == 2:
             image = np.expand_dims(image, 2)


### PR DESCRIPTION
Summary: D35930993 (https://github.com/facebookresearch/d2go/commit/ca094a0a5dbd8012127304b4886a38444d29010d) reformats d2go_dataset_mapper to break circular dependency. This change makes D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)GoDatasetMapper in internal usage not having transforms in the dataset_dict. Some project, e.g. D36268572, requires this transform information to perform inverse transform. Add this information back in D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)GoDatasetMapper.

Differential Revision: D36743751

