### PR TITLE
fix protobuf version issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ requirements = [
     "pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@9b011606f",
     "opencv-python",
     "parameterized",
-    "diskcache",  # TODO: move to mobile_cv
+    # Downgrade the protobuf package to 3.20.x or lower, related:
+    # https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
+    # https://github.com/protocolbuffers/protobuf/issues/10051
+    "protobuf<=3.20.1",
 ]
 
 


### PR DESCRIPTION
Summary:
CI has issue (eg. https://github.com/facebookresearch/d2go/runs/6662620169?check_suite_focus=true):
```
  File "/usr/share/miniconda/envs/__setup_conda/lib/python3.8/site-packages/caffe2/proto/__init__.py", line 15, in <module>
    from caffe2.proto import caffe2_pb2, metanet_pb2, torch_pb2
  File "/usr/share/miniconda/envs/__setup_conda/lib/python3.8/site-packages/caffe2/proto/caffe2_pb2.py", line 33, in <module>
    _descriptor.EnumValueDescriptor(
  File "/usr/share/miniconda/envs/__setup_conda/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

It's caused by BC-breaking change of protobuf, fix the version.

Differential Revision: D36781162

