### PR TITLE
better cleanup for disk_cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ requirements = [
     "pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@9b011606f",
     "opencv-python",
     "parameterized",
-    "diskcache",  # TODO: move to mobile_cv
+    # Downgrade the protobuf package to 3.20.x or lower, related:
+    # https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
+    # https://github.com/protocolbuffers/protobuf/issues/10051
+    "protobuf<=3.20.1",
 ]
 
 


### PR DESCRIPTION
Summary: https://www.internalfb.com/intern/test/281475036363610?ref_report_id=0 is flaky, which is caused by running multiple tests at the same time, and clean up is not handled very well in that case.

Differential Revision: D36787035

