### PR TITLE
DatasetMapper return "transforms"

### DIFF
--- a/d2go/data/dataset_mappers/d2go_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/d2go_dataset_mapper.py
@@ -117,6 +117,10 @@ class D2GoDatasetMapper(object):
             if self.crop_gen:
                 transforms = crop_tfm + transforms
 
+        # Cache identical transforms in dataset_dict for subclass mappers
+        # TODO T122215878 Find more explicit way to expose transforms used
+        dataset_dict["transforms"] = transforms
+
         image_shape = image.shape[:2]  # h, w
         if image.ndim == 2:
             image = np.expand_dims(image, 2)


### PR DESCRIPTION
Summary:
Adding a behavior in which the default D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go dataset mapper returns a dict that contains "transforms" stored in its original call. This enables dataset mapper subclasses to have access to the same transforms performed on the input.

This behavior was originally present in the d2go_dataset_mapper_impl.py and d2go_dataset_mapper_impl_fb.py files, but was lost after the refactor to combine the files.

Proposing to add this feature back in, to fix downstream bugs that relied on this behavior.

Reviewed By: miqueljubert, wat3rBro

Differential Revision: D36790367

