### PR TITLE
unify DDP launcher for elastic and non-elastic (support elastic launch correctly)

### DIFF
--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -196,7 +196,6 @@ def setup_after_launch(
     cfg: CfgNode,
     output_dir: str,
     runner: Optional[BaseRunner] = None,
-    _scale_world_size: bool = True,  # HACK: temporarily allow lightning_train_net to by pass this.
 ):
     """
     Binary-level setup after entering DDP, including
@@ -233,8 +232,7 @@ def setup_after_launch(
         pass
 
     # scale the config after dumping so that dumped config files keep original world size
-    if _scale_world_size:
-        auto_scale_world_size(cfg, new_world_size=comm.get_world_size())
+    auto_scale_world_size(cfg, new_world_size=comm.get_world_size())
 
 
 def setup_logger(

--- a/tests/misc/test_lightning_train_net.py
+++ b/tests/misc/test_lightning_train_net.py
@@ -5,13 +5,12 @@ import os
 import unittest
 
 import numpy as np
-import torch.distributed as dist
 from d2go.config import CfgNode
 from d2go.config.utils import flatten_config_dict
 from d2go.runner.lightning_task import GeneralizedRCNNTask
 from d2go.tools.lightning_train_net import FINAL_MODEL_CKPT, main
 from d2go.utils.testing import meta_arch_helper as mah
-from d2go.utils.testing.helper import tempdir
+from d2go.utils.testing.helper import enable_ddp_env, tempdir
 
 
 class TestLightningTrainNet(unittest.TestCase):
@@ -28,6 +27,7 @@ class TestLightningTrainNet(unittest.TestCase):
         return mah.create_detection_cfg(GeneralizedRCNNTask, tmp_dir)
 
     @tempdir
+    @enable_ddp_env
     def test_train_net_main(self, root_dir):
         """tests the main training entry point."""
         cfg = self._get_cfg(root_dir)
@@ -36,6 +36,7 @@ class TestLightningTrainNet(unittest.TestCase):
         main(cfg, root_dir)
 
     @tempdir
+    @enable_ddp_env
     def test_checkpointing(self, tmp_dir):
         """tests saving and loading from checkpoint."""
         cfg = self._get_cfg(tmp_dir)
@@ -57,7 +58,3 @@ class TestLightningTrainNet(unittest.TestCase):
         accuracy2 = flatten_config_dict(out2.accuracy)
         for k in accuracy:
             np.testing.assert_equal(accuracy[k], accuracy2[k])
-
-    def tearDown(self):
-        if dist.is_initialized():
-            dist.destroy_process_group()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/mobile-vision/pull/76

TLDR: this diff consolidate the `distributed_helper` of `mobile_cv`, it (together with `mobile_cv`'s `comm` module) should be the TOGO library for dealing with DDP. D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go's `distributed` is now built on-top of `mobile_cv`'s `distributed_helper`.

Differential Revision: D36787336

