### PR TITLE
making bootstrap more robust

### DIFF
--- a/d2go/utils/testing/rcnn_helper.py
+++ b/d2go/utils/testing/rcnn_helper.py
@@ -16,7 +16,6 @@ from d2go.utils.testing.data_loader_helper import (
     create_detection_data_loader_on_toy_dataset,
 )
 from detectron2.structures import Boxes, Instances
-from detectron2.utils.testing import assert_instances_allclose
 from mobile_cv.predictor.api import create_predictor
 from parameterized import parameterized
 
@@ -353,6 +352,8 @@ class RCNNBaseTestCases:
                 if compare_match:
                     with torch.no_grad():
                         pytorch_outputs = self.test_model(inputs)
+
+                    from detectron2.utils.testing import assert_instances_allclose
 
                     assert_instances_allclose(
                         predictor_outputs[0]["instances"],


### PR DESCRIPTION
Summary:
- add `MoreMagicMock`, which handles inheritance and comparison.
- also support lazy registering mocked objects (has to be `MoreMagicMock`).
- don't need to skip `skip files that doesn't contain ".register()" call` since we can handle most files pretty well now.
- also mock the open
- delay the import for `from detectron2.utils.testing import assert_instances_allclose`; for some reason python is doing magic things if you import anything starting with `assert`, so the mocked import doesn't work.
- makes log function nicer.

Differential Revision: D36798327

