### PR TITLE
support diff config for lightning_train_net

### DIFF
--- a/tools/lightning_train_net.py
+++ b/tools/lightning_train_net.py
@@ -145,7 +145,7 @@ def main(
         num_processes: Number of processes on each node.
         eval_only: True if run evaluation only.
     """
-    setup_after_launch(cfg, output_dir)
+    setup_after_launch(cfg, output_dir, task_cls)
 
     task = task_cls.from_config(cfg, eval_only)
     trainer_params = get_trainer_params(cfg)


### PR DESCRIPTION
Summary: `setup_after_launch` can now take `DefaultTask` as well (the `runner_or_task` can still be `None`, for runner-less train_net).

Differential Revision: D37011560

