### PR TITLE
Add CallFuncWithNameAndJsonFile

### DIFF
--- a/d2go/data/utils.py
+++ b/d2go/data/utils.py
@@ -101,6 +101,20 @@ class CallFuncWithJsonFile(object):
         return self.func(self.json_file)
 
 
+class CallFuncWithNameAndJsonFile(object):
+    """
+    Same purpose as CallFuncWithJsonFile but also pass name to `func` as arguments
+    """
+
+    def __init__(self, func, json_file, name):
+        self.func = func
+        self.name = name
+        self.json_file = json_file
+
+    def __call__(self):
+        return self.func(self.json_file, self.name)
+
+
 class AdhocCOCODataset(AdhocDataset):
     def __init__(self, src_ds_name, new_ds_name):
         super().__init__(new_ds_name)
@@ -144,6 +158,11 @@ class AdhocCOCODataset(AdhocDataset):
         # re-register DatasetCatalog
         if isinstance(load_func, CallFuncWithJsonFile):
             new_func = CallFuncWithJsonFile(func=load_func.func, json_file=tmp_file)
+            DatasetCatalog.register(self.new_ds_name, new_func)
+        elif isinstance(load_func, CallFuncWithNameAndJsonFile):
+            new_func = CallFuncWithNameAndJsonFile(
+                func=load_func.func, name=self.new_ds_name, json_file=tmp_file
+            )
             DatasetCatalog.register(self.new_ds_name, new_func)
         elif self.src_ds_name in INJECTED_COCO_DATASETS_LUT:
             _src_func, _src_dict = INJECTED_COCO_DATASETS_LUT[self.src_ds_name]


### PR DESCRIPTION
Summary:
Add a new call function to handle adhoc datasets that needs to be called with dataset_name. This is mainly to handle the incompatibility of `extend_coco_load` function with AdhocDataset

For example,
* if we choose to register `extend_coco_load` function as CallFuncWithJsonFile, AdhocDataset will register the same function, while failed to update the `dataset_name` argument passed to `extended_coco_load`.

* If we choose to register `extend_coco_load` function normally, we couldn't use the `LOAD_KWARGS` that specifies additional fields like `image_direct_copy_keys` when register AdhocDatasets

Therefore adding the new function allows to update register function with specifying new json as well as new dataset_name in the same time.

Differential Revision: D37100742

