### PR TITLE
Introduce a helper to convert args to CLI args

### DIFF
--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -7,6 +7,7 @@ Detection Training Script.
 
 import logging
 import sys
+from typing import List, Optional, Union
 
 import detectron2.utils.comm as comm
 from d2go.distributed import launch
@@ -101,6 +102,44 @@ def cli(args):
         help="whether to attempt to resume from the checkpoint directory",
     )
     run_with_cmdline_args(parser.parse_args(args))
+
+
+def build_cli_args(
+    config_path: str,
+    output_dir: str,
+    runner_name: Optional[str] = None,
+    num_processes: Optional[Union[int, str]] = None,
+    num_machines: Optional[Union[int, str]] = None,
+    machine_rank: Optional[Union[int, str]] = None,
+    dist_url: Optional[str] = None,
+    dist_backend: Optional[str] = None,
+    eval_only: bool = False,
+    resume: bool = False,
+) -> List[str]:
+    """Returns parameters in the form of CLI arguments for train_net binary."""
+    args = [
+        "--config-file",
+        config_path,
+        "--output-dir",
+        output_dir,
+    ]
+    if runner_name is not None:
+        args += ["--runner", runner_name]
+    if num_processes is not None:
+        args += ["--num-processes", str(num_processes)]
+    if num_machines is not None:
+        args += ["--num-machines", str(num_machines)]
+    if machine_rank is not None:
+        args += ["--machine-rank", str(machine_rank)]
+    if dist_url is not None:
+        args += ["--dist-url", str(dist_url)]
+    if dist_backend is not None:
+        args += ["--dist-backend", str(dist_backend)]
+    if eval_only:
+        args += ["--eval-only"]
+    if resume:
+        args += ["--resume"]
+    return args
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: When running through torchx, converting from arguments to CLI arguments is necessary.

Differential Revision: D37086938

