### PR TITLE
make launch return results from all ranks

### DIFF
--- a/d2go/distributed.py
+++ b/d2go/distributed.py
@@ -68,7 +68,7 @@ def launch(
     timeout: timedelta = DEFAULT_TIMEOUT,
     args: Tuple[Any, ...] = (),
     kwargs: Dict[str, Any] = None,
-):
+) -> Dict[int, Any]:
     """
     D2Go's specialized launch method, it does a few more things on top of mcv's launch:
         - Automatically convert GPU to CPU if CUDA is not available.


### PR DESCRIPTION
Summary:
Similar to `elastic_launch`, make `launch` return results for all ranks, this is beneficial for cases where each rank having different return value`.

There'll be some test failing for V1, it'll help finding related callsites.

Reviewed By: tglik

Differential Revision: D37016935

