### PR TITLE
fix OSS CLI tools

### DIFF
--- a/tools/evaluator.py
+++ b/tools/evaluator.py
@@ -74,7 +74,7 @@ def run_with_cmdline_args(args):
     )
 
 
-def cli(args):
+def cli(args=None):
     parser = basic_argument_parser()
     parser.add_argument(
         "--predictor-path",
@@ -100,8 +100,9 @@ def cli(args):
         default=0,
         help="Control the --caffe2_logging_print_net_summary in GlobalInit",
     )
-    run_with_cmdline_args(parser.parse_args())
+    args = sys.argv[1:] if args is None else args
+    run_with_cmdline_args(parser.parse_args(args))
 
 
 if __name__ == "__main__":
-    cli(sys.argv[1:])
+    cli()

--- a/tools/exporter.py
+++ b/tools/exporter.py
@@ -122,9 +122,10 @@ def get_parser():
     return parser
 
 
-def cli(args):
+def cli(args=None):
+    args = sys.argv[1:] if args is None else args
     run_with_cmdline_args(get_parser().parse_args(args))
 
 
 if __name__ == "__main__":
-    cli(sys.argv[1:])
+    cli()

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -92,7 +92,7 @@ def run_with_cmdline_args(args):
     )
 
 
-def cli(args):
+def cli(args=None):
     parser = basic_argument_parser(requires_output_dir=False)
     parser.add_argument(
         "--eval-only", action="store_true", help="perform evaluation only"
@@ -102,6 +102,7 @@ def cli(args):
         action="store_true",
         help="whether to attempt to resume from the checkpoint directory",
     )
+    args = sys.argv[1:] if args is None else args
     run_with_cmdline_args(parser.parse_args(args))
 
 
@@ -122,4 +123,4 @@ def build_cli_args(
 
 
 if __name__ == "__main__":
-    cli(sys.argv[1:])
+    cli()


### PR DESCRIPTION
Summary:
Fixing issue introduced in D35035813 (https://github.com/facebookresearch/d2go/commit/744d72d73b7103b8dd9ca69372a179b44ad7d733) that break the OSS cli tools defined in https://github.com/facebookresearch/d2go/blob/8098d160c0b38b796a2c164719650a50238a0f89/setup.py#L87-L92.
The cli alias in setup need a function without any args to call. So creating a new main_cli function

Differential Revision: D37210948

