### PR TITLE
Prototype using AIEnv in D2go e2e flow

### DIFF
--- a/d2go/config/utils.py
+++ b/d2go/config/utils.py
@@ -262,3 +262,17 @@ def resolve_default_config(cfg):
     cfg[DEFAULTS_KEY] = updater_names
 
     return cfg
+
+
+def merge_cfg_lists(cfg_list1: List[str], cfg_list2: List[str]) -> List[str]:
+    """Merge two override cfg lists by merging the config keys and updating the values.
+    The output list will contain all the override params from both lists and will work with
+    cfg.merge_from_list(...).
+    """
+    cfg_dict = {key: val for key, val in zip(cfg_list1[0::2], cfg_list1[1::2])}
+    cfg_dict.update({key: val for key, val in zip(cfg_list2[0::2], cfg_list2[1::2])})
+    merged_list = []
+    for k, v in cfg_dict.items():
+        merged_list.append(k)
+        merged_list.append(v)
+    return merged_list

--- a/tests/misc/test_config.py
+++ b/tests/misc/test_config.py
@@ -19,6 +19,7 @@ from d2go.config.utils import (
     get_cfg_diff_table,
     get_diff_cfg,
     get_from_flattened_config_dict,
+    merge_cfg_lists,
 )
 from d2go.registry.builtin import CONFIG_UPDATER_REGISTRY
 from d2go.runner import GeneralizedRCNNRunner
@@ -215,6 +216,14 @@ class TestConfigUtils(unittest.TestCase):
         self.assertTrue("c0.c1.c2" in table)  # c0.c1.c2 key mismatched
         self.assertTrue("c0.c4.c2" in table)  # c0.c4.c2 key mismatched
         self.assertTrue("Key not exists" in table)  # has mismatched key
+
+    def test_merge_cfg_lists(self):
+        l1 = ["a", "1", "b.b1", "1", "c.c1.c2", "1"]
+        l2 = ["b.b1", "2", "c.c1.c2", "2", "d", "2"]
+
+        merged_list = merge_cfg_lists(l1, l2)
+        expected_results = ["a", "1", "b.b1", "2", "c.c1.c2", "2", "d", "2"]
+        self.assertEqual(merged_list, expected_results)
 
 
 class TestAutoScaleWorldSize(unittest.TestCase):


### PR DESCRIPTION
Summary:
This diff is looking into what would it take to use AI Env with the  d2go e2e_workfow pipeline.
To enable using AIEnv, we are changing current d2go e2e workflow to use d2go binary tools as the workflow steps, removing the current logic in e2e workflow to initialize and manage the state of the runner and the config

Goals:
-
- Correlate the e2e workflow logic to have the same operators as the local binary commands. Having the e2e workflow logic be a thin layer of just the pipeline logic of calling these binaries.
- Be able to easily running each step locally. As the operators are not binaries, it is easy to copy the command line args and run it locally for debug and development.
- Be able to use different launchers to run the binaries. Like using AIEnv or torchX to run on MAST and TC. This will provide flexibility to use future Meta infra for different operations.
- Reduce code duplication and converge multiple code paths in workflow and in d2go binaries

The changes in this diff:
-
- Create e2e_binaries_workflow that include train and eval, calling train_net binary.
- Avoid initialize runner and config in the new workflow. Instead manage the override_cfg_args to override and change pre_training/post_training config
- Add `package_info` configuration to e2e_workflow inputs config to provide the info needed to launch the binaries.
- Launch logic that uses AIEnv to launch train_net CLI
- Add support for serialize the train_net outputs for saving and loading across processes.

Note:
- For testing this diff, the [aienv d2go_demo project](https://www.internalfb.com/intern/wiki/Mobile_Vision/Detectron2Go/D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go_Tutorials/D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go_with_AIEnv_Tutorial/) was used. This demonstrate also using user code from the d2go_demo folder that is not included in the workflow package.
- D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go App code package is created with `starlight app package`
- D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go core base environement is created daily and can be manually created with `starlight env publish d2go`

Follow up to implement in future diffs:
-
- Cleanup diff and add more tests
- Implement distributed processing on multiple hosts, using QF app api
- Remove workflow dependency on user/project code entirely and have only the d2go binaries use user code (using AIEnv)
- Add missing steps (like export_predictors and eval_predictors) to match e2e_workflow functionality
- Add cogwheel test for the new workflow
- Support the new workflow and the creation of d2go app package when using flow launch utils.

Differential Revision: D36915017

