### PR TITLE
Fix test failures caused by https://github.com/pytorch/pytorch/pull/79066 (part 2)

### DIFF
--- a/d2go/modeling/meta_arch/rcnn.py
+++ b/d2go/modeling/meta_arch/rcnn.py
@@ -312,7 +312,7 @@ def default_rcnn_prepare_for_quant_convert(self, cfg):
         assert not isinstance(self.backbone, FPN), "FPN is not supported in FX mode"
         self.backbone = convert_fx(
             self.backbone,
-            convert_custom_config_dict={
+            convert_custom_config={
                 "preserved_attributes": ["size_divisibility", "padding_constraints"]
             },
         )

--- a/tests/runner/test_runner_lightning_task.py
+++ b/tests/runner/test_runner_lightning_task.py
@@ -186,7 +186,7 @@ class TestLightningTask(unittest.TestCase):
 
             def prepare_for_quant_convert(self, cfg):
                 self.avgpool = convert_fx(
-                    self.avgpool, convert_custom_config_dict=self.custom_config_dict
+                    self.avgpool, convert_custom_config=self.custom_config_dict
                 )
                 return self
 


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/79066 made BC breaking changes in PyTorch, but missed
fixing a few callsites. This is the second diff to fix the affected
tests.

Reviewed By: jerryzh168, wat3rBro

Differential Revision: D37282853

