### PR TITLE
use runner class instead of instance outside of main

### DIFF
--- a/d2go/runner/__init__.py
+++ b/d2go/runner/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "GeneralizedRCNNRunner",
     "TRAINER_HOOKS_REGISTRY",
     "create_runner",
+    "import_runner",
 ]
 
 

--- a/tests/misc/test_lightning_train_net.py
+++ b/tests/misc/test_lightning_train_net.py
@@ -33,7 +33,7 @@ class TestLightningTrainNet(unittest.TestCase):
         cfg = self._get_cfg(root_dir)
         # set distributed backend to none to avoid spawning child process,
         # which doesn't inherit the temporary dataset
-        main(cfg, root_dir)
+        main(cfg, root_dir, GeneralizedRCNNTask)
 
     @tempdir
     @enable_ddp_env
@@ -41,7 +41,7 @@ class TestLightningTrainNet(unittest.TestCase):
         """tests saving and loading from checkpoint."""
         cfg = self._get_cfg(tmp_dir)
 
-        out = main(cfg, tmp_dir)
+        out = main(cfg, tmp_dir, GeneralizedRCNNTask)
         ckpts = [f for f in os.listdir(tmp_dir) if f.endswith(".ckpt")]
         expected_ckpts = ("last.ckpt", FINAL_MODEL_CKPT)
         for ckpt in expected_ckpts:
@@ -53,7 +53,7 @@ class TestLightningTrainNet(unittest.TestCase):
         cfg2.MODEL.WEIGHTS = os.path.join(tmp_dir, "last.ckpt")
 
         output_dir = os.path.join(tmp_dir, "output")
-        out2 = main(cfg2, output_dir, eval_only=True)
+        out2 = main(cfg2, output_dir, GeneralizedRCNNTask, eval_only=True)
         accuracy = flatten_config_dict(out.accuracy)
         accuracy2 = flatten_config_dict(out2.accuracy)
         for k in accuracy:

--- a/tests/modeling/test_rcnn_export_example.py
+++ b/tests/modeling/test_rcnn_export_example.py
@@ -24,8 +24,7 @@ def maskrcnn_export_caffe2_vs_torchvision_opset_format_example(self):
             (dataset_name,),
         ]
         # START_WIKI_EXAMPLE_TAG
-        runner = GeneralizedRCNNRunner()
-        cfg = runner.get_default_cfg()
+        cfg = GeneralizedRCNNRunner.get_default_cfg()
         cfg.merge_from_file("detectron2go://mask_rcnn_fbnetv3a_dsmask_C4.yaml")
         cfg.merge_from_list(get_quick_test_config_opts())
         cfg.merge_from_list(config_list)
@@ -35,7 +34,7 @@ def maskrcnn_export_caffe2_vs_torchvision_opset_format_example(self):
         _ = main(
             cfg,
             tmp_dir,
-            runner,
+            GeneralizedRCNNRunner,
             predictor_types=["torchscript@c2_ops", "torchscript"],
         )
 

--- a/tools/lightning_train_net.py
+++ b/tools/lightning_train_net.py
@@ -5,14 +5,14 @@
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 import mobile_cv.torch.utils_pytorch.comm as comm
 import pytorch_lightning as pl  # type: ignore
 from d2go.config import CfgNode
 from d2go.runner import create_runner
 from d2go.runner.callbacks.quantization import QuantizationAwareTraining
-from d2go.runner.lightning_task import GeneralizedRCNNTask
+from d2go.runner.lightning_task import DefaultTask, GeneralizedRCNNTask
 from d2go.setup import basic_argument_parser, setup_after_launch
 from d2go.trainer.lightning.training_loop import _do_test, _do_train
 from detectron2.utils.file_io import PathManager
@@ -92,7 +92,7 @@ def get_trainer_params(cfg: CfgNode) -> Dict[str, Any]:
 def main(
     cfg: CfgNode,
     output_dir: str,
-    task_cls: Type[GeneralizedRCNNTask] = GeneralizedRCNNTask,
+    runner_class: Union[str, Type[DefaultTask]],
     eval_only: bool = False,
 ) -> TrainOutput:
     """Main function for launching a training with lightning trainer
@@ -102,7 +102,7 @@ def main(
         num_processes: Number of processes on each node.
         eval_only: True if run evaluation only.
     """
-    setup_after_launch(cfg, output_dir, task_cls)
+    task_cls: Type[DefaultTask] = setup_after_launch(cfg, output_dir, runner_class)
 
     task = task_cls.from_config(cfg, eval_only)
     trainer_params = get_trainer_params(cfg)
@@ -130,7 +130,7 @@ def main(
 
 def build_config(
     config_file: str,
-    task_cls: Type[GeneralizedRCNNTask],
+    task_cls: Type[DefaultTask],
     opts: Optional[List[str]] = None,
 ) -> CfgNode:
     """Build config node from config file


### PR DESCRIPTION
Summary:
As discussed, we decided to not use runner instance outside of `main`, previous diffs already solved the prerequisites, this diff mainly does the renaming.
- Use runner name (str) in the fblearner, ML pipeline.
- Use runner name (str) in FBL operator, MAST and binary operator.
- Use runner class as the interface of main, it can be either the name of class (str) or actual class. The main usage should be using `str`, so that the importing of class happens inside `main`, But since this is BC breaking, i.e. some scripts or tests will fail without updating, supporting actual class makes it easier modify code for those cases (eg. some local test class doesn't have a name).

Differential Revision: D37060338

