### PR TITLE
use kwargs for extra args in launch

### DIFF
--- a/tools/benchmark_data.py
+++ b/tools/benchmark_data.py
@@ -143,7 +143,10 @@ def run_with_cmdline_args(args):
         machine_rank=args.machine_rank,
         dist_url=args.dist_url,
         backend=args.dist_backend,
-        args=(cfg, output_dir, runner_name, args.is_train),
+        args=(cfg, output_dir, runner_name),
+        kwargs={
+            "is_train": args.is_train,
+        },
     )
 
 

--- a/tools/evaluator.py
+++ b/tools/evaluator.py
@@ -64,16 +64,13 @@ def run_with_cmdline_args(args):
         dist_url=args.dist_url,
         backend="GLOO",
         always_spawn=False,
-        args=(
-            cfg,
-            output_dir,
-            runner_name,
-            # binary specific optional arguments
-            args.predictor_path,
-            args.num_threads,
-            args.caffe2_engine,
-            args.caffe2_logging_print_net_summary,
-        ),
+        args=(cfg, output_dir, runner_name),
+        kwargs={
+            "predictor_path": args.predictor_path,
+            "num_threads": args.num_threads,
+            "caffe2_engine": args.caffe2_engine,
+            "caffe2_logging_print_net_summary": args.caffe2_logging_print_net_summary,
+        },
     )
 
 

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -94,7 +94,11 @@ def run_with_cmdline_args(args):
         machine_rank=args.machine_rank,
         dist_url=args.dist_url,
         backend=args.dist_backend,
-        args=(cfg, output_dir, runner_name, args.eval_only, args.resume),
+        args=(cfg, output_dir, runner_name),
+        kwargs={
+            "eval_only": args.eval_only,
+            "resume": args.resume,
+        },
     )
 
     # Only save results from global rank 0 for consistency.


### PR DESCRIPTION
Summary: MCV/D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go's `launch` now supports `kwargs`, which matches elastic launch. Let's always use `args=(cfg, output_dir, runner_name)` for all the binaries, and use `kwargs` for remaining binary arguments (which matches the `extra_args` in FBL's OperatorArgument).

Differential Revision: D37535145

