### PR TITLE
Follow up fixes for example_inputs refactor

### DIFF
--- a/d2go/runner/lightning_task.py
+++ b/d2go/runner/lightning_task.py
@@ -476,10 +476,11 @@ class DefaultTask(pl.LightningModule):
                 rank_zero_info("Loaded EMA state from checkpoint.")
 
     def prepare_for_quant(self) -> pl.LightningModule:
+        example_input = self.model.example_input
         if hasattr(self.model, "prepare_for_quant"):
-            self.model = self.model.prepare_for_quant(self.cfg)
+            self.model = self.model.prepare_for_quant(self.cfg, example_input)
         else:
-            self.model = default_prepare_for_quant(self.cfg, self.model)
+            self.model = default_prepare_for_quant(self.cfg, self.model, example_input)
         return self
 
     def prepare_for_quant_convert(self) -> pl.LightningModule:

--- a/d2go/utils/testing/meta_arch_helper.py
+++ b/d2go/utils/testing/meta_arch_helper.py
@@ -26,6 +26,11 @@ class DetMetaArchForTest(torch.nn.Module):
     def device(self):
         return self.conv.weight.device
 
+    @property
+    def example_input(self):
+        # TODO[quant-example-inputs]: set example_input properly
+        return torch.randn(1, 3, 224, 224)
+
     def forward(self, inputs):
         if not self.training:
             return self.inference(inputs)
@@ -52,7 +57,8 @@ class DetMetaArchForTest(torch.nn.Module):
         ret = [{"instances": instance}]
         return ret
 
-    def prepare_for_quant(self, cfg):
+    def prepare_for_quant(self, cfg, example_input=None):
+        # TODO[quant-example-inputs]: use example_input
         example_inputs = (torch.rand(1, 3, 3, 3),)
         self.avgpool = prepare_qat_fx(
             self.avgpool,

--- a/tests/runner/test_runner_default_runner.py
+++ b/tests/runner/test_runner_default_runner.py
@@ -228,7 +228,7 @@ class TestDefaultRunner(unittest.TestCase):
 
         @META_ARCH_REGISTRY.register()
         class MetaArchForTestQAT(MetaArchForTest):
-            def prepare_for_quant(self, cfg):
+            def prepare_for_quant(self, cfg, example_inputs=None):
                 """Set the qconfig to updateable observers"""
                 self.qconfig = updateable_symmetric_moving_avg_minmax_config
                 return self


### PR DESCRIPTION
Summary:
Following up the bc-breaking change from fx graph mode quantization: https://github.com/pytorch/pytorch/pull/76496 that
added example_inputs to prepare_fx and prepare_qat_fx, we fixes the callsite related to mobile-vision and exposed
extra example_inputs in some apis

Reviewed By: wat3rBro

Differential Revision: D37163018

