### PR TITLE
Add AugMix Transform in D2go

### DIFF
--- a/tests/data/test_data_transforms_auto_aug.py
+++ b/tests/data/test_data_transforms_auto_aug.py
@@ -44,3 +44,21 @@ class TestDataTransformsAutoAug(unittest.TestCase):
 
         self.assertEqual(img.shape, trans_img.shape)
         self.assertEqual(img.dtype, trans_img.dtype)
+
+    def test_aug_mix_transforms(self):
+        default_cfg = Detectron2GoRunner().get_default_cfg()
+        img = np.concatenate(
+            [
+                (np.random.uniform(0, 1, size=(80, 60, 1)) * 255).astype(np.uint8),
+                (np.random.uniform(0, 1, size=(80, 60, 1)) * 255).astype(np.uint8),
+                (np.random.uniform(0, 1, size=(80, 60, 1)) * 255).astype(np.uint8),
+            ],
+            axis=2,
+        )
+
+        default_cfg.D2GO_DATA.AUG_OPS.TRAIN = ['AugMixImageOp::{"severity": 3}']
+        tfm = build_transform_gen(default_cfg, is_train=True)
+        trans_img, _ = apply_augmentations(tfm, img)
+
+        self.assertEqual(img.shape, trans_img.shape)
+        self.assertEqual(img.dtype, trans_img.dtype)


### PR DESCRIPTION
Summary: TorchVision has recently added the AugMix Augmentantion. This diff adds support of the specific transform to D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)go

Differential Revision: D37578243

