### PR TITLE
Change registry from detectron to mobile_cv

### DIFF
--- a/d2go/modeling/modeling_hook.py
+++ b/d2go/modeling/modeling_hook.py
@@ -5,15 +5,7 @@ from abc import abstractmethod
 from typing import List
 
 import torch
-from detectron2.utils.registry import Registry
-
-MODELING_HOOK_REGISTRY = Registry("MODELING_HOOK")  # noqa F401 isort:skip
-MODELING_HOOK_REGISTRY.__doc__ = """
-Registry for modeling hook.
-
-The registered object will be called with `obj(cfg)`
-and expected to return a `ModelingHook` object.
-"""
+from d2go.registry.builtin import MODELING_HOOK_REGISTRY
 
 
 class ModelingHook(object):

--- a/d2go/registry/builtin.py
+++ b/d2go/registry/builtin.py
@@ -22,6 +22,15 @@ CONFIG_UPDATER_REGISTRY = Registry("CONFIG_UPDATER")
 # Registry for meta-arch, registered nn.Module should follow D2Go's meta-arch API
 META_ARCH_REGISTRY = Registry("META_ARCH")
 
+# Modeling hook registry
+MODELING_HOOK_REGISTRY = Registry("MODELING_HOOK")
+MODELING_HOOK_REGISTRY.__doc__ = """
+Registry for modeling hook.
+
+The registered object will be called with `obj(cfg)`
+and expected to return a `ModelingHook` object.
+"""
+
 # Distillation algorithms
 DISTILLATION_ALGORITHM_REGISTRY = Registry("DISTILLATION_ALGORITHM")
 


### PR DESCRIPTION
Summary: Changing Registry from `fvcore` with the `mobile_cv` one, because `mobile_cv` allows registering with custom name (i.e. `SOME_REGISTRY.register("name")`)

Reviewed By: wat3rBro

Differential Revision: D37600026

