### PR TITLE
Move ema_state to ModelingHook

### DIFF
--- a/d2go/modeling/ema.py
+++ b/d2go/modeling/ema.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import logging
+
+from d2go.config import CfgNode
+from d2go.modeling import modeling_hook as mh
+from d2go.registry.builtin import MODELING_HOOK_REGISTRY
+from d2go.utils.ema_state import EMAState
+from torch import nn
+
+logger = logging.getLogger(__name__)
+
+
+@MODELING_HOOK_REGISTRY.register("EMA")
+class EMAModelingHook(mh.ModelingHook):
+    """Modeling hook to attach"""
+
+    def __init__(self, cfg: CfgNode):
+        super().__init__(cfg)
+
+        self.cfg = cfg
+
+        # "EMA" will be always specified in MODEL.MODELING_HOOKS in config
+        self.ema_enabled = cfg.MODEL_EMA.ENABLED
+
+        if not self.ema_enabled:
+            return
+
+        self.ema_state = EMAState(
+            decay=cfg.MODEL_EMA.DECAY, device=cfg.MODEL_EMA.DEVICE or cfg.MODEL.DEVICE
+        )
+
+    def apply(self, model: nn.Module) -> nn.Module:
+        """If EMA is not enabled, this is no-op, returning original model."""
+        if not self.ema_enabled:
+            return model
+        model.ema_state = self.ema_state
+
+        return model
+
+    def unapply(self, model: nn.Module) -> nn.Module:
+        if not self.ema_enabled:
+            return model
+        del model.ema_state
+        return model

--- a/tests/runner/test_runner_lightning_task.py
+++ b/tests/runner/test_runner_lightning_task.py
@@ -23,6 +23,10 @@ from torch import Tensor
 from torch.ao.quantization.quantize_fx import convert_fx, prepare_qat_fx
 
 
+DEFAULT_EMA_DECAY: float = 0.7
+EMA_HOOK_KEY: str = "EMA"
+
+
 class TestLightningTask(unittest.TestCase):
     def _get_cfg(self, tmp_dir: str) -> CfgNode:
         cfg = mah.create_detection_cfg(GeneralizedRCNNTask, tmp_dir)
@@ -74,9 +78,12 @@ class TestLightningTask(unittest.TestCase):
     def test_train_ema(self, tmp_dir):
         cfg = self._get_cfg(tmp_dir)
         cfg.MODEL_EMA.ENABLED = True
-        cfg.MODEL_EMA.DECAY = 0.7
+        cfg.MODEL_EMA.DECAY = DEFAULT_EMA_DECAY
+        cfg.MODEL.MODELING_HOOKS = [EMA_HOOK_KEY]
         task = GeneralizedRCNNTask(cfg)
         init_state = deepcopy(task.model.state_dict())
+
+        self.assertTrue(hasattr(task.model, "ema_state"))
 
         trainer = self._get_trainer(tmp_dir)
         with EventStorage() as storage:
@@ -84,16 +91,20 @@ class TestLightningTask(unittest.TestCase):
             trainer.fit(task)
 
         for k, v in task.model.state_dict().items():
-            init_state[k].copy_(init_state[k] * 0.7 + 0.3 * v)
+            init_state[k].copy_(
+                init_state[k] * DEFAULT_EMA_DECAY + (1.0 - DEFAULT_EMA_DECAY) * v
+            )
 
         self.assertTrue(
-            self._compare_state_dict(init_state, task.ema_state.state_dict())
+            self._compare_state_dict(init_state, task.model.ema_state.state_dict()),
         )
 
     @tempdir
     def test_load_ema_weights(self, tmp_dir):
         cfg = self._get_cfg(tmp_dir)
         cfg.MODEL_EMA.ENABLED = True
+        cfg.MODEL.MODELING_HOOKS = [EMA_HOOK_KEY]
+
         task = GeneralizedRCNNTask(cfg)
         trainer = self._get_trainer(tmp_dir)
         with EventStorage() as storage:
@@ -106,15 +117,15 @@ class TestLightningTask(unittest.TestCase):
         )
         self.assertTrue(
             self._compare_state_dict(
-                task.ema_state.state_dict(), task2.ema_state.state_dict()
+                task.model.ema_state.state_dict(), task2.model.ema_state.state_dict()
             )
         )
 
         # apply EMA weights to model
-        task2.ema_state.apply_to(task2.model)
+        task2.model.ema_state.apply_to(task2.model)
         self.assertTrue(
             self._compare_state_dict(
-                task.ema_state.state_dict(), task2.model.state_dict()
+                task.model.ema_state.state_dict(), task2.model.state_dict()
             )
         )
 
@@ -128,6 +139,8 @@ class TestLightningTask(unittest.TestCase):
     def test_build_model(self, tmp_dir):
         cfg = self._get_cfg(tmp_dir)
         cfg.MODEL_EMA.ENABLED = True
+        cfg.MODEL.MODELING_HOOKS = [EMA_HOOK_KEY]
+
         task = GeneralizedRCNNTask(cfg)
         trainer = self._get_trainer(tmp_dir)
 
@@ -148,6 +161,9 @@ class TestLightningTask(unittest.TestCase):
                 self._compare_state_dict(model.state_dict(), task.model.state_dict())
             )
 
+        # check if model has EMA:
+        self.assertTrue(hasattr(model, "ema_state"))
+
         # test loading EMA weights
         with temp_defrost(cfg):
             cfg.MODEL.WEIGHTS = os.path.join(tmp_dir, "last.ckpt")
@@ -156,7 +172,7 @@ class TestLightningTask(unittest.TestCase):
             self.assertFalse(model.training)
             self.assertTrue(
                 self._compare_state_dict(
-                    model.state_dict(), task.ema_state.state_dict()
+                    model.ema_state.state_dict(), task.model.ema_state.state_dict()
                 )
             )
 


### PR DESCRIPTION
Summary:
In this diff, remove `ema_state` from LightningTask / DefaultTask.
We attach ema_state in the ModelingHook, because we remove the training hooks in the next diff.

Differential Revision: D37521511

