### PR TITLE
re-enable lightning task's test_qat

### DIFF
--- a/d2go/runner/callbacks/quantization.py
+++ b/d2go/runner/callbacks/quantization.py
@@ -99,7 +99,7 @@ def checkpoint_has_prepared(checkpoint: Dict[str, Any]) -> bool:
 def maybe_prepare_for_quantization(model: LightningModule, checkpoint: Dict[str, Any]):
     if checkpoint_has_prepared(checkpoint) and not hasattr(model, PREPARED):
         # model has been prepared for QAT before saving into checkpoint
-        setattr(model, PREPARED, _deepcopy(model).prepare_for_quant())
+        setattr(model, PREPARED, _deepcopy(model).custom_prepare_fx())
 
 
 class QuantizationMixin(ABC):
@@ -161,8 +161,8 @@ class QuantizationMixin(ABC):
         Returns:
             The prepared Module to be used for quantized aware training.
         """
-        if hasattr(root, "prepare_for_quant"):
-            return root.prepare_for_quant()
+        if hasattr(root, "custom_prepare_fx"):
+            return root.custom_prepare_fx()
         prep_fn = (
             prepare_qat_fx
             if isinstance(self, QuantizationAwareTraining)

--- a/d2go/utils/testing/meta_arch_helper.py
+++ b/d2go/utils/testing/meta_arch_helper.py
@@ -26,11 +26,6 @@ class DetMetaArchForTest(torch.nn.Module):
     def device(self):
         return self.conv.weight.device
 
-    @property
-    def example_input(self):
-        # TODO[quant-example-inputs]: set example_input properly
-        return torch.randn(1, 3, 224, 224)
-
     def forward(self, inputs):
         if not self.training:
             return self.inference(inputs)
@@ -57,8 +52,7 @@ class DetMetaArchForTest(torch.nn.Module):
         ret = [{"instances": instance}]
         return ret
 
-    def prepare_for_quant(self, cfg, example_input=None):
-        # TODO[quant-example-inputs]: use example_input
+    def custom_prepare_fx(self, cfg, example_input=None):
         example_inputs = (torch.rand(1, 3, 3, 3),)
         self.avgpool = prepare_qat_fx(
             self.avgpool,

--- a/tests/runner/test_runner_lightning_task.py
+++ b/tests/runner/test_runner_lightning_task.py
@@ -161,9 +161,6 @@ class TestLightningTask(unittest.TestCase):
             )
 
     @tempdir
-    @unittest.skip(
-        "FX Graph Mode Quantization API has been updated, re-enable the test after PyTorch 1.13 stable release"
-    )
     def test_qat(self, tmp_dir):
         @META_ARCH_REGISTRY.register()
         class QuantizableDetMetaArchForTest(mah.DetMetaArchForTest):
@@ -174,7 +171,7 @@ class TestLightningTask(unittest.TestCase):
                 self.avgpool.preserved_attr = "foo"
                 self.avgpool.not_preserved_attr = "bar"
 
-            def prepare_for_quant(self, cfg):
+            def custom_prepare_fx(self, cfg, example_input=None):
                 example_inputs = (torch.rand(1, 3, 3, 3),)
                 self.avgpool = prepare_qat_fx(
                     self.avgpool,


### PR DESCRIPTION
Summary:
- re-enable the `test_qat`
- remove `example_input` from `DetMetaArchForTest`, since its `custom_prepare_fx` just create a tensor for avgpool.

Differential Revision: D37793260

