### PR TITLE
remove example input from eager-mode-only models

### DIFF
--- a/tests/runner/test_runner_default_runner.py
+++ b/tests/runner/test_runner_default_runner.py
@@ -228,7 +228,7 @@ class TestDefaultRunner(unittest.TestCase):
 
         @META_ARCH_REGISTRY.register()
         class MetaArchForTestQAT(MetaArchForTest):
-            def prepare_for_quant(self, cfg, example_inputs=None):
+            def prepare_for_quant(self, cfg):
                 """Set the qconfig to updateable observers"""
                 self.qconfig = updateable_symmetric_moving_avg_minmax_config
                 return self


### PR DESCRIPTION
Summary: Manually remove `example_input` from eager-mode-only `prepare_for_quant`.

Reviewed By: jerryzh168

Differential Revision: D37838155

