### PR TITLE
add cfg option to control the frequency of the writers

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -120,6 +120,9 @@ def get_base_runner_default_cfg(cfg: CN) -> CN:
 
     cfg.SOLVER.AUTO_SCALING_METHODS = ["default_scale_d2_configs"]
 
+    # Frequency of metric printer, tensorboard writer, etc.
+    cfg.WRITER_PERIOD = 20
+
     return cfg
 
 

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -471,7 +471,7 @@ class Detectron2GoRunner(BaseRunner):
                 JSONWriter(os.path.join(cfg.OUTPUT_DIR, "metrics.json")),
                 tbx_writer,
             ]
-            trainer_hooks.append(hooks.PeriodicWriter(writers))
+            trainer_hooks.append(hooks.PeriodicWriter(writers, cfg.WRITER_PERIOD))
         update_hooks_from_registry(trainer_hooks)
         trainer.register_hooks(trainer_hooks)
         trainer.train(start_iter, max_iter)


### PR DESCRIPTION
Summary:
Add a cfg option to control the frequency of the writers.

Currently, the default writers include:
```
writers = [
    CommonMetricPrinter(max_iter),
    JSONWriter(os.path.join(cfg.OUTPUT_DIR, "metrics.json")),
    tbx_writer,
]
```

Differential Revision: D38065583

