### PR TITLE
EMA parity / change build_d2go_model

### DIFF
--- a/d2go/modeling/modeling_hook.py
+++ b/d2go/modeling/modeling_hook.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from abc import abstractmethod
-from typing import List
+from typing import List, Tuple
 
 import torch
 from d2go.registry.builtin import MODELING_HOOK_REGISTRY
@@ -85,7 +85,7 @@ def _apply_modeling_hooks(
 
 def build_and_apply_modeling_hooks(
     model: torch.nn.Module, cfg, hook_names: List[str]
-) -> torch.nn.Module:
+) -> Tuple[torch.nn.Module, List[ModelingHook]]:
     """Build modeling hooks from cfg and apply hooks on the model. Users could
     call model.unapply_modeling_hooks() to return the model that removes all
     the hooks.
@@ -93,4 +93,4 @@ def build_and_apply_modeling_hooks(
     hooks = _build_modeling_hooks(cfg, hook_names)
     model = _apply_modeling_hooks(model, hooks)
 
-    return model
+    return model, hooks

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -58,6 +58,7 @@ from detectron2.solver import build_lr_scheduler as d2_build_lr_scheduler
 from detectron2.utils.events import CommonMetricPrinter, JSONWriter
 from mobile_cv.common.misc.oss_utils import fb_overwritable
 from mobile_cv.predictor.api import PredictorWrapper
+from torch import nn
 
 
 logger = logging.getLogger(__name__)
@@ -163,9 +164,9 @@ class BaseRunner(object):
     def get_default_cfg(cls):
         return get_base_runner_default_cfg(CfgNode())
 
-    def build_model(self, cfg, eval_only=False):
+    def build_model(self, cfg, eval_only=False) -> nn.Module:
         # cfg may need to be reused to build trace model again, thus clone
-        model = build_d2go_model(cfg.clone())
+        model = build_d2go_model(cfg.clone()).model
 
         if eval_only:
             checkpointer = DetectionCheckpointer(model, save_dir=cfg.OUTPUT_DIR)
@@ -206,7 +207,7 @@ class Detectron2GoRunner(BaseRunner):
         # build_model might modify the cfg, thus clone
         cfg = cfg.clone()
 
-        model = build_d2go_model(cfg)
+        model = build_d2go_model(cfg).model
         model_ema.may_build_model_ema(cfg, model)
 
         if cfg.MODEL.FROZEN_LAYER_REG_EXP:

--- a/tests/modeling/test_modeling_meta_arch_modeling_hook.py
+++ b/tests/modeling/test_modeling_meta_arch_modeling_hook.py
@@ -4,12 +4,13 @@
 
 import copy
 import unittest
+from typing import List
 
 import d2go.runner.default_runner as default_runner
 import torch
 from d2go.config import CfgNode
 from d2go.modeling import modeling_hook as mh
-from d2go.modeling.api import build_d2go_model
+from d2go.modeling.api import build_d2go_model, D2GoModelBuildResult
 from d2go.registry.builtin import META_ARCH_REGISTRY, MODELING_HOOK_REGISTRY
 
 
@@ -84,8 +85,13 @@ class TestModelingHook(unittest.TestCase):
         cfg.MODEL.DEVICE = "cpu"
         cfg.MODEL.META_ARCHITECTURE = "TestArch"
         cfg.MODEL.MODELING_HOOKS = ["PlusOneHook", "TimesTwoHook"]
-        model = build_d2go_model(cfg)
+
+        model_info: D2GoModelBuildResult = build_d2go_model(cfg)
+        model: torch.nn.Module = model_info.model
+        modeling_hooks: List[mh.ModelingHook] = model_info.modeling_hooks
+
         self.assertEqual(model(2), 10)
+        self.assertEqual(len(modeling_hooks), 2)
 
         self.assertTrue(hasattr(model, "_modeling_hooks"))
         self.assertTrue(hasattr(model, "unapply_modeling_hooks"))
@@ -118,8 +124,13 @@ class TestModelingHook(unittest.TestCase):
         cfg.MODEL.DEVICE = "cpu"
         cfg.MODEL.META_ARCHITECTURE = "TestArch"
         cfg.MODEL.MODELING_HOOKS = ["PlusOneHook", "TimesTwoHook"]
-        model = build_d2go_model(cfg)
+
+        model_info: D2GoModelBuildResult = build_d2go_model(cfg)
+        model: torch.nn.Module = model_info.model
+        modeling_hooks: List[mh.ModelingHook] = model_info.modeling_hooks
+
         self.assertEqual(model(2), 10)
+        self.assertEqual(len(modeling_hooks), 2)
 
         model_copy = copy.deepcopy(model)
 


### PR DESCRIPTION
Summary: we need access to the modeling hooks in EMA, e.g. build trainer.

Differential Revision: D37997773

