### PR TITLE
use public trainer API to re-create data loader for QAT

### DIFF
--- a/d2go/quantization/modeling.py
+++ b/d2go/quantization/modeling.py
@@ -616,8 +616,4 @@ def _reset_qat_data_loader_if_needed(cfg, trainer, build_loader_func):
         )
         # This method assumes the data loader can be replaced from trainer
         assert trainer.__class__ == SimpleTrainer
-        del trainer._data_loader_iter
-        del trainer.data_loader
-        data_loader = build_loader_func(loader_cfg)
-        trainer.data_loader = data_loader
-        trainer._data_loader_iter = iter(data_loader)
+        trainer.reset_data_loader(lambda: build_loader_func(loader_cfg))


### PR DESCRIPTION
Summary:
- The QAT was using old code prior to D36786902, update to use public API
- Make `trainer:reset_data_loader` to take lazy lambda expression in order to delay the creation of dataloader. It's possible that we don't have enough RAM to hold two data loader at the same time, so we need to delete the first one, then create the second one.

Differential Revision: D38330148

