### PR TITLE
Add Adam optimizer in D2Go

### DIFF
--- a/d2go/optimizer/build.py
+++ b/d2go/optimizer/build.py
@@ -255,6 +255,19 @@ def sgd(cfg, model: torch.nn.Module) -> torch.optim.Optimizer:
 
 
 @D2GO_OPTIM_MAPPER_REGISTRY.register()
+def adam(cfg, model: torch.nn.Module) -> torch.optim.Optimizer:
+    """
+    Build an optimizer from config.
+    """
+    params = get_optimizer_param_groups(model, cfg)
+
+    optim = maybe_add_gradient_clipping(cfg, torch.optim.Adam)(
+        params, cfg.SOLVER.BASE_LR, betas=cfg.SOLVER.BETAS
+    )
+    return optim
+
+
+@D2GO_OPTIM_MAPPER_REGISTRY.register()
 def adamw(cfg, model: torch.nn.Module) -> torch.optim.Optimizer:
     """
     Build an optimizer from config.

--- a/tests/modeling/test_optimizer.py
+++ b/tests/modeling/test_optimizer.py
@@ -163,7 +163,7 @@ class TestOptimizer(unittest.TestCase):
         cfg = runner.get_default_cfg()
         multipliers = [None, [{"conv": 0.1}]]
 
-        for optimizer_name in ["SGD", "AdamW", "SGD_MT", "AdamW_MT"]:
+        for optimizer_name in ["SGD", "AdamW", "SGD_MT", "AdamW_MT", "Adam"]:
             for mult in multipliers:
                 cfg.SOLVER.BASE_LR = 0.01
                 cfg.SOLVER.OPTIMIZER = optimizer_name
@@ -174,7 +174,7 @@ class TestOptimizer(unittest.TestCase):
         runner = default_runner.Detectron2GoRunner()
         cfg = runner.get_default_cfg()
 
-        for optimizer_name in ["SGD", "AdamW", "SGD_MT", "AdamW_MT"]:
+        for optimizer_name in ["SGD", "AdamW", "SGD_MT", "AdamW_MT", "Adam"]:
             cfg.SOLVER.BASE_LR = 0.02
             cfg.SOLVER.CLIP_GRADIENTS.CLIP_VALUE = 0.2
             cfg.SOLVER.CLIP_GRADIENTS.ENABLED = True


### PR DESCRIPTION
Summary: Currently, D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go is missing the Adam optimizer. This Diff addresses the gap.

Differential Revision: D38492151

