### PR TITLE
Support confusion matrix as a metric

### DIFF
--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Type, Union
 
 import d2go.utils.abnormal_checker as abnormal_checker
 import detectron2.utils.comm as comm
+import seaborn as sn
 import torch
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
@@ -367,7 +368,13 @@ class Detectron2GoRunner(BaseRunner):
             flattened_results = flatten_results_dict(results)
             for k, v in flattened_results.items():
                 tbx_writer = self.get_tbx_writer(cfg)
-                tbx_writer._writer.add_scalar("eval_{}".format(k), v, train_iter)
+                if "confusion_matrix" in k:
+                    cm_fig = sn.heatmap(v, annot=True).get_figure()
+                    tbx_writer._writer.add_figure(
+                        "eval_{}".format(k), cm_fig, train_iter
+                    )
+                else:
+                    tbx_writer._writer.add_scalar("eval_{}".format(k), v, train_iter)
 
         if comm.is_main_process():
             tbx_writer = self.get_tbx_writer(cfg)

--- a/d2go/trainer/api.py
+++ b/d2go/trainer/api.py
@@ -7,15 +7,15 @@ Trainer APIs on which D2Go's binary can build on top.
 """
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from d2go.evaluation.api import AccuracyDict, MetricsDict
 
 # TODO (T127368935) Split to TrainNetOutput and TestNetOutput
 @dataclass
 class TrainNetOutput:
-    accuracy: AccuracyDict[float]
-    metrics: MetricsDict[float]
+    accuracy: AccuracyDict[Any]
+    metrics: MetricsDict[Any]
     # Optional, because we use None to distinguish "not used" from
     # empty model configs. With T127368935, this should be reverted to dict.
     model_configs: Optional[Dict[str, str]]

--- a/tools/benchmark_data.py
+++ b/tools/benchmark_data.py
@@ -7,7 +7,7 @@ Tool for benchmarking data loading
 import logging
 import time
 from dataclasses import dataclass
-from typing import Type, Union
+from typing import Any, Type, Union
 
 import detectron2.utils.comm as comm
 import numpy as np
@@ -31,8 +31,8 @@ logger = logging.getLogger("d2go.tools.benchmark_data")
 
 @dataclass
 class BenchmarkDataOutput:
-    accuracy: AccuracyDict[float]
-    metrics: MetricsDict[float]
+    accuracy: AccuracyDict[Any]
+    metrics: MetricsDict[Any]
 
 
 def main(

--- a/tools/evaluator.py
+++ b/tools/evaluator.py
@@ -9,7 +9,7 @@ torchscript, caffe2, etc.) using Detectron2Go system (dataloading, evaluation, e
 import logging
 import sys
 from dataclasses import dataclass
-from typing import Optional, Type, Union
+from typing import Any, Optional, Type, Union
 
 import torch
 from d2go.config import CfgNode
@@ -31,8 +31,8 @@ logger = logging.getLogger("d2go.tools.caffe2_evaluator")
 
 @dataclass
 class EvaluatorOutput:
-    accuracy: AccuracyDict[float]
-    metrics: MetricsDict[float]
+    accuracy: AccuracyDict[Any]
+    metrics: MetricsDict[Any]
 
 
 def main(


### PR DESCRIPTION
Summary: The existing image classification runner only outputs accuracy. This change also outputs a confusion matrix. This enables others to get a better snapshot of the model performance and compute other derived metrics such as precision and recall.

Differential Revision: D38122918

