### PR TITLE
change default quantization calibration iteration to larger value

### DIFF
--- a/d2go/quantization/modeling.py
+++ b/d2go/quantization/modeling.py
@@ -145,7 +145,7 @@ def add_quantization_default_configs(_C):
 
     # post-training quantization
     _C.QUANTIZATION.PTQ = CfgNode()
-    _C.QUANTIZATION.PTQ.CALIBRATION_NUM_IMAGES = 1
+    _C.QUANTIZATION.PTQ.CALIBRATION_NUM_IMAGES = 16  # NOTE: this is actually iterations
     _C.QUANTIZATION.PTQ.CALIBRATION_FORCE_ON_GPU = False
 
     # register deprecated and renamed keys


### PR DESCRIPTION
Summary: Users often time just use the default value without knowing they need to change  this config, and getting low accuracy after PTQ. Therefore increase the default value.

Differential Revision: D39331680

