### PR TITLE
make sure the return result is consistent for ResultCache

### DIFF
--- a/d2go/evaluation/evaluator.py
+++ b/d2go/evaluation/evaluator.py
@@ -80,11 +80,11 @@ class ResultCache(object):
         gather (bool): gather cache results arcoss ranks to a list
         """
         if self.cache_file is None or not PathManager.exists(self.cache_file):
-            return None
-
-        with PathManager.open(self.cache_file, "rb") as fp:
-            ret = torch.load(fp)
-        logger.info(f"Loaded from checkpoint {self.cache_file}")
+            ret = None
+        else:
+            with PathManager.open(self.cache_file, "rb") as fp:
+                ret = torch.load(fp)
+            logger.info(f"Loaded from checkpoint {self.cache_file}")
 
         if gather:
             ret = comm.all_gather(ret)

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -87,6 +87,7 @@ def default_scale_d2_configs(cfg, new_world_size):
     base_lr = cfg.SOLVER.BASE_LR
     base_lr_end = cfg.SOLVER.BASE_LR_END
     max_iter = cfg.SOLVER.MAX_ITER
+    checkpoint_period = cfg.SOLVER.CHECKPOINT_PERIOD
     steps = cfg.SOLVER.STEPS
     eval_period = cfg.TEST.EVAL_PERIOD
     ims_per_batch_train = cfg.SOLVER.IMS_PER_BATCH
@@ -105,6 +106,7 @@ def default_scale_d2_configs(cfg, new_world_size):
     cfg.SOLVER.BASE_LR = base_lr * lr_scale
     cfg.SOLVER.BASE_LR_END = base_lr_end * lr_scale
     cfg.SOLVER.MAX_ITER = int(round(max_iter / gpu_scale))
+    cfg.SOLVER.CHECKPOINT_PERIOD = int(round(checkpoint_period / gpu_scale))
     cfg.SOLVER.STEPS = tuple(int(round(s / gpu_scale)) for s in steps)
     cfg.TEST.EVAL_PERIOD = int(round(eval_period / gpu_scale))
     cfg.SOLVER.IMS_PER_BATCH = int(round(ims_per_batch_train * gpu_scale))

--- a/tests/misc/test_config.py
+++ b/tests/misc/test_config.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
+import copy
 import glob
 import logging
 import os
@@ -226,9 +227,14 @@ class TestAutoScaleWorldSize(unittest.TestCase):
         self.assertEqual(cfg.SOLVER.REFERENCE_WORLD_SIZE, 8)
         batch_size_x8 = cfg.SOLVER.IMS_PER_BATCH
         assert batch_size_x8 % 8 == 0, "default batch size is not multiple of 8"
+        orig_cfg = copy.deepcopy(cfg)
         auto_scale_world_size(cfg, new_world_size=1)
         self.assertEqual(cfg.SOLVER.REFERENCE_WORLD_SIZE, 1)
         self.assertEqual(cfg.SOLVER.IMS_PER_BATCH * 8, batch_size_x8)
+        self.assertEqual(cfg.SOLVER.MAX_ITER // 8, orig_cfg.SOLVER.MAX_ITER)
+        self.assertEqual(
+            cfg.SOLVER.CHECKPOINT_PERIOD // 8, orig_cfg.SOLVER.CHECKPOINT_PERIOD
+        )
 
     def test_not_scale_for_zero_world_size(self):
         """


### PR DESCRIPTION
Summary:
Make sure the return result is consistent for ResultCache
* When gather = True, it will always return a list.

Differential Revision: D39874274

