### PR TITLE
Add "float16" and "bfloat16" precision when training with lightning Task

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -69,6 +69,9 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     _C.SOLVER.LR_MULTIPLIER_OVERWRITE = []
     _C.SOLVER.WEIGHT_DECAY_EMBED = 0.0
     _C.SOLVER.WEIGHT_DECAY_OVERWRITE = []
+    assert not _C.SOLVER.AMP.ENABLED
+    # AMP precision is used by the lightning backend. Can be "float16" or "bfloat16".
+    _C.SOLVER.AMP.PRECISION = "float16"
 
     # Betas are used in the AdamW optimizer
     _C.SOLVER.BETAS = (0.9, 0.999)


### PR DESCRIPTION
Summary:
Introduce extra parameter SOLVER.AMP.PRECISION which can be sued to control the mixed precision training when lightning  backend is used.

Previous value `precision: "mixed"` was worng and the training failed (See screenshot below)
{F777576618}

I had to make AMP.PRECISION as string and make sure that it can work with two values: "float16" and "bfloat16". Before feeding it to the Trainer we convert "float16" string to integer value 16. Such a workaround was unavoidable because D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go's config value cannot be of int and str at the same time.

Differential Revision: D40035367

