### PR TITLE
Retry API Integration

### DIFF
--- a/d2go/quantization/fx.py
+++ b/d2go/quantization/fx.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+
+from typing import Tuple
+
+import torch
+from mobile_cv.common.misc.oss_utils import fb_overwritable
+
+
+TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
+if TORCH_VERSION > (1, 10):
+    from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
+else:
+    from torch.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
+
+
+@fb_overwritable()
+def get_prepare_fx_fn(cfg, is_qat):
+    return prepare_qat_fx if is_qat else prepare_fx
+
+
+@fb_overwritable()
+def get_convert_fx_fn(cfg, example_inputs):
+    return convert_fx

--- a/d2go/quantization/qconfig.py
+++ b/d2go/quantization/qconfig.py
@@ -9,6 +9,7 @@ if TORCH_VERSION > (1, 10):
     from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
 else:
     from torch.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
+from mobile_cv.common.misc.oss_utils import fb_overwritable
 
 
 QCONFIG_CREATOR_REGISTRY = Registry("QCONFIG_CREATOR_REGISTRY")
@@ -82,6 +83,7 @@ def validate_native_backend(backend):
         )
 
 
+@fb_overwritable()
 def _smart_parse_extended_backend(extended_backend):
     """
     D2Go extends the definition of quantization "backend". In addition to PyTorch's


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/d2go/pull/382

Pull Request resolved: https://github.com/facebookresearch/d2go/pull/364

As title,
when `QUANTIZATION.BACKEND` is set to `turing`, call `odai.transforms` APIs instead of OSS quantization.

Also updated `image_classification` as an example to get Turing quantized model via `custom_prepare_fx/custom_convert_fx`

Differential Revision: D40282390

