### PR TITLE
Set logger level to info for d2go tools which do not have it set

### DIFF
--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -35,6 +35,21 @@ from mobile_cv.common.misc.py import FolderLock, MultiprocessingPdb, post_mortem
 logger = logging.getLogger(__name__)
 
 
+def setup_root_logger(logging_level: int = logging.DEBUG) -> None:
+    """
+    Sets up the D2Go root logger. When a new logger is created, it lies in a tree.
+    If the logger being used does not have a specific level being specified, it
+    will default to using its parent logger. In this case, by setting the root
+    logger level to debug, or what is given, we change the default behaviour
+    for all loggers.
+
+    See https://docs.python.org/3/library/logging.html for a more in-depth
+    description
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging_level)
+
+
 def basic_argument_parser(
     distributed=True,
     requires_output_dir=True,

--- a/tools/evaluator.py
+++ b/tools/evaluator.py
@@ -24,7 +24,9 @@ from d2go.setup import (
     prepare_for_launch,
     setup_after_launch,
     setup_before_launch,
+    setup_root_logger,
 )
+
 from d2go.utils.misc import print_metrics_table
 from mobile_cv.predictor.api import create_predictor
 
@@ -119,4 +121,5 @@ def cli(args=None):
 
 
 if __name__ == "__main__":
+    setup_root_logger()
     cli()

--- a/tools/exporter.py
+++ b/tools/exporter.py
@@ -23,6 +23,7 @@ from d2go.setup import (
     prepare_for_launch,
     setup_after_launch,
     setup_before_launch,
+    setup_root_logger,
 )
 
 
@@ -147,4 +148,5 @@ def cli(args=None):
 
 
 if __name__ == "__main__":
+    setup_root_logger()
     cli()

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -20,6 +20,7 @@ from d2go.setup import (
     prepare_for_launch,
     setup_after_launch,
     setup_before_launch,
+    setup_root_logger,
 )
 from d2go.trainer.api import TrainNetOutput
 from d2go.utils.misc import (
@@ -148,4 +149,5 @@ def build_cli_args(
 
 
 if __name__ == "__main__":
+    setup_root_logger()
     cli()


### PR DESCRIPTION
Summary: Make the logging level be info instead of the default.

Differential Revision: D40377653

