### PR TITLE
Add shared workers context API

### DIFF
--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -22,6 +22,7 @@ from d2go.data.utils import (
     maybe_subsample_n_images,
     update_cfg_if_using_adhoc_dataset,
 )
+from d2go.distributed import D2GoSharedContext
 from d2go.evaluation.evaluator import inference_on_dataset
 from d2go.modeling import kmeans_anchors, model_ema
 from d2go.modeling.api import build_d2go_model
@@ -59,7 +60,6 @@ from detectron2.utils.events import CommonMetricPrinter, JSONWriter
 from mobile_cv.common.misc.oss_utils import fb_overwritable
 from mobile_cv.predictor.api import PredictorWrapper
 from torch import nn
-
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +156,13 @@ class BaseRunner(object):
         Override `register` in order to run customized code before other things like:
             - registering datasets.
             - registering model using Registry.
+        """
+        pass
+
+    @classmethod
+    def create_shared_context(cls, cfg) -> D2GoSharedContext:
+        """
+        Override `create_shared_context` in order to run customized code to create distributed shared context that can be accessed by all workers
         """
         pass
 

--- a/tools/evaluator.py
+++ b/tools/evaluator.py
@@ -23,6 +23,7 @@ from d2go.setup import (
     post_mortem_if_fail_for_main,
     prepare_for_launch,
     setup_after_launch,
+    setup_before_launch,
 )
 from d2go.utils.misc import print_metrics_table
 from mobile_cv.predictor.api import create_predictor
@@ -66,6 +67,7 @@ def main(
 
 def run_with_cmdline_args(args):
     cfg, output_dir, runner_name = prepare_for_launch(args)
+    shared_context = setup_before_launch(cfg, output_dir, runner_name)
     main_func = main if args.disable_post_mortem else post_mortem_if_fail_for_main(main)
     launch(
         main_func,
@@ -75,6 +77,7 @@ def run_with_cmdline_args(args):
         dist_url=args.dist_url,
         backend="GLOO",
         always_spawn=False,
+        shared_context=shared_context,
         args=(cfg, output_dir, runner_name),
         kwargs={
             "predictor_path": args.predictor_path,

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -19,6 +19,7 @@ from d2go.setup import (
     post_mortem_if_fail_for_main,
     prepare_for_launch,
     setup_after_launch,
+    setup_before_launch,
 )
 from d2go.trainer.api import TrainNetOutput
 from d2go.utils.misc import (
@@ -93,6 +94,7 @@ def main(
 
 def run_with_cmdline_args(args):
     cfg, output_dir, runner_name = prepare_for_launch(args)
+    shared_context = setup_before_launch(cfg, output_dir, runner_name)
 
     main_func = main if args.disable_post_mortem else post_mortem_if_fail_for_main(main)
     outputs = launch(
@@ -102,6 +104,7 @@ def run_with_cmdline_args(args):
         machine_rank=args.machine_rank,
         dist_url=args.dist_url,
         backend=args.dist_backend,
+        shared_context=shared_context,
         args=(cfg, output_dir, runner_name),
         kwargs={
             "eval_only": args.eval_only,


### PR DESCRIPTION
Summary:
D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go doesn't have per node initialization api, but only per worker initialization that happens per subprocess.
Some projects (like IOBT) need to way to do shared initialization before spawning all the workers in subprocess and pass this initialized shared context to the workers.
This diff adds API to create a shared context object before launching workers and then use this shared context by the runners inside the workers after launch.

Reviewed By: wat3rBro

Differential Revision: D40001329

