### PR TITLE
use class method when calling Runner::get_default_cfg

### DIFF
--- a/tests/data/test_data_transforms.py
+++ b/tests/data/test_data_transforms.py
@@ -12,7 +12,7 @@ from detectron2.data.transforms import apply_transform_gens
 
 class TestDataTransforms(unittest.TestCase):
     def test_build_transform_gen(self):
-        default_cfg = Detectron2GoRunner().get_default_cfg()
+        default_cfg = Detectron2GoRunner.get_default_cfg()
         default_cfg.INPUT.MIN_SIZE_TRAIN = (30,)
         default_cfg.INPUT.MIN_SIZE_TEST = 30
 
@@ -27,7 +27,7 @@ class TestDataTransforms(unittest.TestCase):
         self.assertEqual(trans_img_test.shape, (40, 30, 3))
 
     def test_build_transform_gen_resize_square(self):
-        default_cfg = Detectron2GoRunner().get_default_cfg()
+        default_cfg = Detectron2GoRunner.get_default_cfg()
         default_cfg.INPUT.MIN_SIZE_TRAIN = (30,)
         default_cfg.INPUT.MIN_SIZE_TEST = 40
         default_cfg.D2GO_DATA.AUG_OPS.TRAIN = ["ResizeShortestEdgeSquareOp"]

--- a/tests/data/test_data_transforms_auto_aug.py
+++ b/tests/data/test_data_transforms_auto_aug.py
@@ -12,7 +12,7 @@ from detectron2.data.transforms import apply_augmentations
 
 class TestDataTransformsAutoAug(unittest.TestCase):
     def test_rand_aug_transforms(self):
-        default_cfg = Detectron2GoRunner().get_default_cfg()
+        default_cfg = Detectron2GoRunner.get_default_cfg()
         img = np.concatenate(
             [
                 (np.random.uniform(0, 1, size=(80, 60, 1)) * 255).astype(np.uint8),
@@ -30,7 +30,7 @@ class TestDataTransformsAutoAug(unittest.TestCase):
         self.assertEqual(img.dtype, trans_img.dtype)
 
     def test_trivial_aug_transforms(self):
-        default_cfg = Detectron2GoRunner().get_default_cfg()
+        default_cfg = Detectron2GoRunner.get_default_cfg()
         img = np.concatenate(
             [
                 (np.random.uniform(0, 1, size=(80, 60, 1)) * 255).astype(np.uint8),
@@ -46,7 +46,7 @@ class TestDataTransformsAutoAug(unittest.TestCase):
         self.assertEqual(img.dtype, trans_img.dtype)
 
     def test_aug_mix_transforms(self):
-        default_cfg = Detectron2GoRunner().get_default_cfg()
+        default_cfg = Detectron2GoRunner.get_default_cfg()
         img = np.concatenate(
             [
                 (np.random.uniform(0, 1, size=(80, 60, 1)) * 255).astype(np.uint8),

--- a/tests/data/test_data_transforms_blur.py
+++ b/tests/data/test_data_transforms_blur.py
@@ -12,7 +12,7 @@ from detectron2.data.transforms import apply_augmentations
 
 class TestDataTransformsBlur(unittest.TestCase):
     def test_gaussian_blur_transforms(self):
-        default_cfg = Detectron2GoRunner().get_default_cfg()
+        default_cfg = Detectron2GoRunner.get_default_cfg()
         img = np.zeros((80, 60, 3)).astype(np.uint8)
 
         img[40, 30, :] = 255

--- a/tests/data/test_data_transforms_color_yuv.py
+++ b/tests/data/test_data_transforms_color_yuv.py
@@ -13,7 +13,7 @@ from detectron2.data.transforms import apply_augmentations
 
 class TestDataTransformsColorYUV(unittest.TestCase):
     def test_yuv_color_transforms(self):
-        default_cfg = Detectron2GoRunner().get_default_cfg()
+        default_cfg = Detectron2GoRunner.get_default_cfg()
         img = np.concatenate(
             [
                 np.random.uniform(0, 1, size=(80, 60, 1)),

--- a/tests/misc/test_config.py
+++ b/tests/misc/test_config.py
@@ -40,11 +40,11 @@ class TestConfig(unittest.TestCase):
             self.assertGreater(len(files), 0)
             for fn in sorted(files):
                 logger.info("Loading {}...".format(fn))
-                GeneralizedRCNNRunner().get_default_cfg().merge_from_file(fn)
+                GeneralizedRCNNRunner.get_default_cfg().merge_from_file(fn)
 
     def test_load_arch_defs(self):
         """Test arch def str-to-dict conversion compatible with merging"""
-        default_cfg = GeneralizedRCNNRunner().get_default_cfg()
+        default_cfg = GeneralizedRCNNRunner.get_default_cfg()
         cfg = default_cfg.clone()
         cfg.merge_from_file(get_resource_path("arch_def_merging.yaml"))
 
@@ -59,7 +59,7 @@ class TestConfig(unittest.TestCase):
             another_cfg.merge_from_file(file_name)
 
     def test_base_reroute(self):
-        default_cfg = GeneralizedRCNNRunner().get_default_cfg()
+        default_cfg = GeneralizedRCNNRunner.get_default_cfg()
 
         # use rerouted file as base
         cfg = default_cfg.clone()
@@ -75,7 +75,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(cfg.OUTPUT_DIR, "test")  # non-base is loaded
 
     def test_default_cfg_dump_and_load(self):
-        default_cfg = GeneralizedRCNNRunner().get_default_cfg()
+        default_cfg = GeneralizedRCNNRunner.get_default_cfg()
 
         cfg = default_cfg.clone()
         with make_temp_directory("detectron2go_tmp") as tmp_dir:
@@ -88,7 +88,7 @@ class TestConfig(unittest.TestCase):
             cfg.merge_from_file(file_name)
 
     def test_default_cfg_deprecated_keys(self):
-        default_cfg = GeneralizedRCNNRunner().get_default_cfg()
+        default_cfg = GeneralizedRCNNRunner.get_default_cfg()
 
         # a warning will be printed for deprecated keys
         default_cfg.merge_from_list(["QUANTIZATION.QAT.LOAD_PRETRAINED", True])
@@ -222,7 +222,7 @@ class TestAutoScaleWorldSize(unittest.TestCase):
         """
         when scaling a 8-gpu config to 1-gpu one, the batch size will be reduced by 8x
         """
-        cfg = GeneralizedRCNNRunner().get_default_cfg()
+        cfg = GeneralizedRCNNRunner.get_default_cfg()
         self.assertEqual(cfg.SOLVER.REFERENCE_WORLD_SIZE, 8)
         batch_size_x8 = cfg.SOLVER.IMS_PER_BATCH
         assert batch_size_x8 % 8 == 0, "default batch size is not multiple of 8"
@@ -234,7 +234,7 @@ class TestAutoScaleWorldSize(unittest.TestCase):
         """
         when reference world size is 0, no scaling should happen
         """
-        cfg = GeneralizedRCNNRunner().get_default_cfg()
+        cfg = GeneralizedRCNNRunner.get_default_cfg()
         self.assertEqual(cfg.SOLVER.REFERENCE_WORLD_SIZE, 8)
         cfg.SOLVER.REFERENCE_WORLD_SIZE = 0
         batch_size_x8 = cfg.SOLVER.IMS_PER_BATCH

--- a/tests/modeling/test_rpn_heads.py
+++ b/tests/modeling/test_rpn_heads.py
@@ -25,7 +25,7 @@ class TestRPNHeads(unittest.TestCase):
 
         for name, builder in rpn.RPN_HEAD_REGISTRY._obj_map.items():
             logger.info("Testing {}...".format(name))
-            cfg = GeneralizedRCNNRunner().get_default_cfg()
+            cfg = GeneralizedRCNNRunner.get_default_cfg()
             if name in RPN_CFGS:
                 cfg.merge_from_file(RPN_CFGS[name])
 
@@ -71,7 +71,7 @@ class TestRPNHeads(unittest.TestCase):
 
         for name, builder in rpn.RPN_HEAD_REGISTRY._obj_map.items():
             logger.info("Testing {}...".format(name))
-            cfg = GeneralizedRCNNRunner().get_default_cfg()
+            cfg = GeneralizedRCNNRunner.get_default_cfg()
             if name in RPN_CFGS:
                 cfg.merge_from_file(RPN_CFGS[name])
 


### PR DESCRIPTION
Summary: `get_default_cfg` is now class method since stack of D37294926 (https://github.com/facebookresearch/d2go/commit/b077a2c13845d4ef8481979d64345368864fe5ff), this diff updates call sites using biggrep to replace "Runner().get_default_cfg" with "Runner.get_default_cfg"

Differential Revision: D40707898

