### PR TITLE
use SharedList as offload backend of DatasetFromList by default

### DIFF
--- a/d2go/data/disk_cache.py
+++ b/d2go/data/disk_cache.py
@@ -8,7 +8,6 @@ import shutil
 import uuid
 
 import numpy as np
-import torch.utils.data as data
 from detectron2.utils import comm
 from detectron2.utils.logger import log_every_n_seconds
 
@@ -41,10 +40,9 @@ def _local_master_gather(func, check_equal=False):
     return x_local_master
 
 
-class DiskCachedDatasetFromList(data.Dataset):
+class DiskCachedList(object):
     """
-    Wrap a list to a torch Dataset, the underlying storage is off-loaded to disk to
-    save RAM usage.
+    Wrap a list, the underlying storage is off-loaded to disk to save RAM usage.
     """
 
     def __init__(self, lst, strategy="batched_static"):

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -18,7 +18,7 @@ from d2go.data.dataset_mappers import build_dataset_mapper
 from d2go.data.datasets import inject_coco_datasets, register_dynamic_datasets
 from d2go.data.transforms.build import build_transform_gen
 from d2go.data.utils import (
-    enable_disk_cached_dataset,
+    configure_dataset_creation,
     maybe_subsample_n_images,
     update_cfg_if_using_adhoc_dataset,
 )
@@ -508,14 +508,14 @@ class Detectron2GoRunner(BaseRunner):
         logger.info(
             "Building detection test loader for dataset: {} ...".format(dataset_name)
         )
-        with enable_disk_cached_dataset(cfg):
+        with configure_dataset_creation(cfg):
             mapper = mapper or cls.get_mapper(cfg, is_train=False)
             logger.info("Using dataset mapper:\n{}".format(mapper))
             return d2_build_detection_test_loader(cfg, dataset_name, mapper=mapper)
 
     @classmethod
     def build_detection_train_loader(cls, cfg, *args, mapper=None, **kwargs):
-        with enable_disk_cached_dataset(cfg):
+        with configure_dataset_creation(cfg):
             mapper = mapper or cls.get_mapper(cfg, is_train=True)
             data_loader = build_d2go_train_loader(cfg, mapper)
             return cls._attach_visualizer_to_data_loader(cfg, data_loader)

--- a/tests/data/test_data_loader.py
+++ b/tests/data/test_data_loader.py
@@ -8,8 +8,8 @@ import tempfile
 import unittest
 
 import torch
-from d2go.data.disk_cache import DiskCachedDatasetFromList, ROOT_CACHE_DIR
-from d2go.data.utils import enable_disk_cached_dataset
+from d2go.data.disk_cache import DiskCachedList, ROOT_CACHE_DIR
+from d2go.data.utils import configure_dataset_creation
 from d2go.runner import create_runner
 from d2go.utils.testing.data_loader_helper import (
     create_detection_data_loader_on_toy_dataset,
@@ -76,10 +76,10 @@ class TestDiskCachedDataLoader(unittest.TestCase):
         return len(os.listdir(ROOT_CACHE_DIR))
 
     def test_disk_cached_dataset_from_list(self):
-        """Test the class of DiskCachedDatasetFromList"""
+        """Test the class of DiskCachedList"""
         # check the discache can handel different data types
         lst = [1, torch.tensor(2), _MyClass(3)]
-        disk_cached_lst = DiskCachedDatasetFromList(lst)
+        disk_cached_lst = DiskCachedList(lst)
         self.assertEqual(len(disk_cached_lst), 3)
         self.assertEqual(disk_cached_lst[0], 1)
         self.assertEqual(disk_cached_lst[1].item(), 2)
@@ -109,7 +109,7 @@ class TestDiskCachedDataLoader(unittest.TestCase):
 
         # enable the disk cache
         cfg.merge_from_list(["D2GO_DATA.DATASETS.DISK_CACHE.ENABLED", "True"])
-        with enable_disk_cached_dataset(cfg):
+        with configure_dataset_creation(cfg):
             # no cache dir in the beginning
             self.assertEqual(self._count_cache_dirs(), 0)
 


### PR DESCRIPTION
Summary:
- Use the non-hacky way (added in D40818736, https://github.com/facebookresearch/detectron2/pull/4626) to customize offloaded backend for DatasetFromList.
- In `D2Go`, switch to use `SharedList` (added in D40789062, https://github.com/facebookresearch/mobile-vision/pull/120) by default to save RAM and optionally use `DiskCachedList` to further save RAM.

Local benchmarking results (using a ~2.4 GiB dataset):
| RAM usage (RES, SHR) | No-dataset | Naive | NumpySerializedList | SharedList | DiskCachedList |
| -- | -- | -- | -- | -- | -- |
| Master GPU worker.         | 8.0g, 2.8g | 21.4g, 2.8g | 11.6g, 2.8g | 11.5g, 5.2g | -- |
| Non-master GPU worker  | 7.5g, 2.8g | 21.0g, 2.8g | 11.5g, 2.8g | 8.0g, 2.8g | -- |
| Per data loader worker     | 2.0g, 1.0g | 14.0g, 1.0g | 4.4g, 1.0g | 2.1g, 1.0g | -- |

- The memory usage (RES, SHR) is found from `top` command. `RES` is total memory used per process; `SHR` shows how much RAM can be shared inside `RES`.
- experiments are done using 2 GPU and 2 data loader workers per GPU, so there're 6 processes in total, the **numbers are per-process**.
- `No-dataset`: running the same job with tiny dataset (only 4.47 MiB after serialization), since RAM usage should be negligible, it shows the floor RAM usage.
- other experiments are running using a dataset of the size of **2413.57 MiB** after serialization.
  - `Naive`: vanilla version if we don't offload the dataset to other storage.
  - `NumpySerializedList`: this optimization was added a long time ago in D19896490. I recalled that the RAM was indeed shared for data loader worker, but seems that there was a regression. Now basically all the processes have a copy of data.
  - `SharedList`: is enabled in this diff. It shows that only the master GPU needs extra RAM. It's interesting that it uses 3.5GB RAM more than other rank, while the data itself is 2.4GB. I'm not so sure if it's overhead of the storage itself or the overhead caused by sharing it with other processes, since non-master GPU using `NumpySerializedList` also uses 11.5g of RAM, we probably don't need to worry too much about it.
  - `DiskCachedList`: didn't benchmark, should have no extra RAM usage.



Differential Revision: D40819959

