### PR TITLE
Use parallel version of SGD optimizer

### DIFF
--- a/d2go/optimizer/build.py
+++ b/d2go/optimizer/build.py
@@ -251,6 +251,7 @@ def sgd(cfg, model: torch.nn.Module) -> torch.optim.Optimizer:
         cfg.SOLVER.BASE_LR,
         momentum=cfg.SOLVER.MOMENTUM,
         nesterov=cfg.SOLVER.NESTEROV,
+        foreach=True,
     )
 
 


### PR DESCRIPTION
Summary:
Profiling yielded the training could benefit from using the parallel version of the SGD optimizer.
Passing `foreach=True` to enable.

Differential Revision: D40798214

