### PR TITLE
add option to load checkpoints to GPU

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -100,6 +100,9 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     # Profiler
     _C.PROFILERS = ["default_flop_counter"]
 
+    # Checkpointing-specific config
+    _C.LOAD_CKPT_TO_GPU = False
+
     # Add FB specific configs
     _add_detectron2go_runner_default_fb_cfg(_C)
 

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -482,6 +482,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
             cfg,
             model,
             save_dir=cfg.OUTPUT_DIR,
+            load_ckpt_to_gpu=cfg.LOAD_CKPT_TO_GPU,
             optimizer=optimizer,
             scheduler=scheduler,
         )


### PR DESCRIPTION
Summary:
Add config option `cfg.LOAD_CKPT_TO_GPU` to load checkpoints to the worker's current GPU

Previously, D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)go maps checkpoints to CPU before loading them to the model. In large-scale distributed training, many GPU processes may be used to train a model. This means each process will load the model checkpoint to a single CPU, causing the same model checkpoint to be loaded many times. This would cause CPU OOM issue when the model checkpoint size is large.

There're two solutions to this problem. One is to load checkpoints to GPU; the other one is to use share memory for the checkpoint between different GPU processes. This diff implements the first solution, which can support cases where model size + model checkpoint size is smaller than the total GPU memory. The second solution may be revisited for large models that need to offload checkpoints to cpu. Reference diff: D40789062

Differential Revision: D41063306

