### PR TITLE
update teacher to support models where device is a property

### DIFF
--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -315,6 +315,14 @@ def _build_teacher(cfg) -> nn.Module:
         from d2go.runner import import_runner
         from d2go.setup import create_cfg_from_cli
 
+        # teacher config may be set to cuda
+        # if user wants to run teacher on cpu only machine by specifying teacher.device,
+        # need to override device to cpu before building model
+        if cfg.DISTILLATION.TEACHER.DEVICE:
+            cfg.DISTILLATION.TEACHER.OVERWRITE_OPTS.extend(
+                ["MODEL.DEVICE", cfg.DISTILLATION.TEACHER.DEVICE]
+            )
+
         teacher_cfg = create_cfg_from_cli(
             cfg.DISTILLATION.TEACHER.CONFIG_FNAME,
             cfg.DISTILLATION.TEACHER.OVERWRITE_OPTS,

--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -335,9 +335,24 @@ def _build_teacher(cfg) -> nn.Module:
 
     # move teacher to same device as student unless specified
     device = torch.device(cfg.DISTILLATION.TEACHER.DEVICE or cfg.MODEL.DEVICE)
-    model = model.to(device)
-    model.device = device
+    model = _set_device(model, device)
     model.eval()
+    return model
+
+
+def _set_device(model: nn.Module, device: torch.device) -> nn.Module:
+    """Set the device of the model
+
+    Some D2Go models have device as a property of the model (e.g., GeneralizedRCNN)
+    whereas others are missing this attribute which is assumed by distillation
+    to exist (e.g., we may call teacher.device to move inputs)
+
+    This helper function guarantees that the model.device attribute exists
+    and runs model.to(device)
+    """
+    model = model.to(device)
+    if not hasattr(model, "device"):
+        model.device = device
     return model
 
 


### PR DESCRIPTION
Summary: Distillation assumes teacher model has an attribute "device". Sometimes this attribute is actually a property (e.g., generalizedrcnn) but there is zero guarantee that it exists. We add a helper function to move the model to the device and add this attribute if needed.

Reviewed By: chihyaoma

Differential Revision: D40283954

