### PR TITLE
support a layer that saves outputs

### DIFF
--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -14,7 +14,7 @@
 # distillation algorithms in configs: DISILLATION_ALAGORITHM, DISTILLATION_HELPER
 
 from abc import abstractmethod
-from typing import List
+from typing import Dict, List, Union
 
 import torch
 import torch.nn as nn
@@ -376,3 +376,62 @@ def _validate_teacher_config(cfg: CN) -> None:
         raise ValueError(
             f"Unrecognized DISTILLATION.TEACHER.TYPE: {cfg.DISTILLATION.TEACHER.TYPE}"
         )
+
+
+class CachedLayer(nn.Module):
+    """Cached layer records the output of a layer
+
+    This is meant to be used with dynamic mixin. The layer overrides the forward
+    of the original layer such that the input and the output is the same but
+    the output of the layer is saved to a dict that can be retrieved later
+    """
+
+    def dynamic_mixin_init(
+        self,
+        label: str,
+        cache: Dict[
+            str, Union[torch.Tensor, List[torch.Tensor], Dict[str, torch.Tensor]]
+        ],
+    ):
+        self.label = label
+        self.cache = cache
+
+    def remove_dynamic_mixin(self):
+        del self.label
+        del self.cache
+
+    def forward(self, *args, **kwargs):
+        """Run the original layer and save the output
+
+        We clone the output to avoid the case where a subsequent module
+        runs an inplace operation. However, this limits what the cache
+        can support as we can only run clone on a tensor so we need to
+        check the type of the output.
+
+        Support of the output type is limited to:
+          * tensor
+          * List[tensor]
+          * Dict[str, tensor]
+        """
+        output = super().forward(*args, **kwargs)
+        if isinstance(output, torch.Tensor):
+            self.cache[self.label] = output.clone()
+        elif isinstance(output, List):
+            cloned_output = []
+            for x in output:
+                if isinstance(x, torch.Tensor):
+                    cloned_output.append(x.clone())
+                else:
+                    raise ValueError(f"Unexpected type to save: {type(x)}")
+            self.cache[self.label] = cloned_output
+        elif isinstance(output, Dict):
+            cloned_output = {}
+            for k, v in output.items():
+                if isinstance(v, torch.Tensor):
+                    cloned_output[k] = v.clone()
+                else:
+                    raise ValueError(f"Unexpected type to save: {type(v)}")
+            self.cache[self.label] = cloned_output
+        else:
+            raise ValueError(f"Unexpected type to save: {type(output)}")
+        return output

--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -315,6 +315,14 @@ def _build_teacher(cfg) -> nn.Module:
         from d2go.runner import import_runner
         from d2go.setup import create_cfg_from_cli
 
+        # teacher config may be set to cuda
+        # if user wants to run teacher on cpu only machine by specifying teacher.device,
+        # need to override device to cpu before building model
+        if cfg.DISTILLATION.TEACHER.DEVICE:
+            cfg.DISTILLATION.TEACHER.OVERWRITE_OPTS.extend(
+                ["MODEL.DEVICE", cfg.DISTILLATION.TEACHER.DEVICE]
+            )
+
         teacher_cfg = create_cfg_from_cli(
             cfg.DISTILLATION.TEACHER.CONFIG_FNAME,
             cfg.DISTILLATION.TEACHER.OVERWRITE_OPTS,

--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -335,9 +335,24 @@ def _build_teacher(cfg) -> nn.Module:
 
     # move teacher to same device as student unless specified
     device = torch.device(cfg.DISTILLATION.TEACHER.DEVICE or cfg.MODEL.DEVICE)
-    model = model.to(device)
-    model.device = device
+    model = _set_device(model, device)
     model.eval()
+    return model
+
+
+def _set_device(model: nn.Module, device: torch.device) -> nn.Module:
+    """Set the device of the model
+
+    Some D2Go models have device as a property of the model (e.g., GeneralizedRCNN)
+    whereas others are missing this attribute which is assumed by distillation
+    to exist (e.g., we may call teacher.device to move inputs)
+
+    This helper function guarantees that the model.device attribute exists
+    and runs model.to(device)
+    """
+    model = model.to(device)
+    if not hasattr(model, "device"):
+        model.device = device
     return model
 
 


### PR DESCRIPTION
Summary:
This diff adds a layer `CachedLayer` which is meant to be used with dynamic mixin. This layer runs the original module and clones the output into a dictionary provided by the user.

The main use case is in distillation where we dynamically mixin these layers to the layers that the user wants to compute various losses.

See subsequent diffs to get integration with distillation.

Reviewed By: Minione

Differential Revision: D40285573

