### PR TITLE
Revert D41350485: Multisect successfully blamed D41350485 for test or build failures

### DIFF
--- a/d2go/runner/lightning_task.py
+++ b/d2go/runner/lightning_task.py
@@ -407,9 +407,9 @@ class DefaultTask(pl.LightningModule):
 
     @classmethod
     def build_detection_train_loader(cls, cfg, *args, mapper=None, **kwargs):
-        return Detectron2GoRunner.build_detection_train_loader(
-            cfg, *args, mapper=mapper, **kwargs
-        )
+        mapper = mapper or cls.get_mapper(cfg, is_train=True)
+        data_loader = build_d2go_train_loader(cfg, mapper)
+        return cls._attach_visualizer_to_data_loader(cfg, data_loader)
 
     @staticmethod
     def build_detection_test_loader(cfg, dataset_name, mapper=None):
@@ -417,7 +417,12 @@ class DefaultTask(pl.LightningModule):
 
     @classmethod
     def _attach_visualizer_to_data_loader(cls, cfg, data_loader):
-        return Detectron2GoRunner._attach_visualizer_to_data_loader(cfg, data_loader)
+        if comm.is_main_process():
+            data_loader_type = cls.get_data_loader_vis_wrapper()
+            if data_loader_type is not None:
+                tbx_writer = Detectron2GoRunner.get_tbx_writer(cfg)
+                data_loader = data_loader_type(cfg, tbx_writer, data_loader)
+        return data_loader
 
     # ---------------------------------------------------------------------------
     # Hooks


### PR DESCRIPTION
Summary:
This diff is reverting D41350485 (https://github.com/facebookresearch/d2go/commit/0ea6bc1b61ab736ccf1840c58c2b19ed2e9a1282)
D41350485 (https://github.com/facebookresearch/d2go/commit/0ea6bc1b61ab736ccf1840c58c2b19ed2e9a1282) has been identified to be causing the following test or build failures:
Tests affected:
- https://www.internalfb.com/intern/test/281475052494930/
- https://www.internalfb.com/intern/test/844425005925528/
- https://www.internalfb.com/intern/test/562950029222822/

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1429252
Here are the tasks that are relevant to this breakage:
T120995919: 4 tests started failing for oncall d2go in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Reviewed By: wat3rBro

Differential Revision: D41470376

