### PR TITLE
support registering layer losses to model

### DIFF
--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -459,6 +459,8 @@ def _build_teacher(cfg) -> nn.Module:
         )
         runner = import_runner(cfg.DISTILLATION.TEACHER.RUNNER_NAME)()
         model = runner.build_model(teacher_cfg, eval_only=True)
+    elif cfg.DISTILLATION.TEACHER.TYPE == "no_teacher":
+        model = nn.Identity()
     else:
         raise ValueError(f"Unexpected teacher type: {cfg.DISTILLATION.TEACHER.TYPE}")
 
@@ -492,6 +494,10 @@ def _validate_teacher_config(cfg: CN) -> None:
         * torchscript_filename
     If config, needs:
         * config_fname
+
+    Bypass allowed if setting teacher.type = "no_teacher". This can be
+    useful in cases where we only have the student model
+    (e.g., domain adaptation)
     """
     if cfg.DISTILLATION.TEACHER.TYPE == "torchscript":
         assert (
@@ -501,6 +507,8 @@ def _validate_teacher_config(cfg: CN) -> None:
         assert (
             cfg.DISTILLATION.TEACHER.CONFIG_FNAME
         ), "Trying to load D2Go teacher model without config"
+    elif cfg.DISTILLATION.TEACHER.TYPE == "no_teacher":
+        pass
     else:
         raise ValueError(
             f"Unrecognized DISTILLATION.TEACHER.TYPE: {cfg.DISTILLATION.TEACHER.TYPE}"

--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -566,6 +566,13 @@ class CachedLayer(nn.Module):
         return output
 
 
+def set_cache_dict(model: nn.Module, cache: Dict) -> None:
+    """Sets the cache in all CachedLayers to input cache"""
+    for module in model.modules():
+        if isinstance(module, CachedLayer):
+            module.cache = cache
+
+
 def record_layers(model: nn.Module, layer_names: Set[str]) -> Dict[str, torch.Tensor]:
     """Save the outputs of layer_names in model
 

--- a/tests/modeling/test_modeling_distillation.py
+++ b/tests/modeling/test_modeling_distillation.py
@@ -253,6 +253,15 @@ class TestDistillation(unittest.TestCase):
             model = _build_teacher(cfg)
             self.assertEqual(gt_model.weight, model.weight)
 
+    def test_build_teacher_none(self):
+        """Check that we can ignore building the teacher"""
+        # build model
+        cfg = _get_default_cfg()
+        cfg.MODEL.META_ARCHITECTURE = "TestMetaArchAddRand"
+        cfg.DISTILLATION.TEACHER.TYPE = "no_teacher"
+        model = _build_teacher(cfg)
+        self.assertTrue(isinstance(model, nn.Module))
+
     def test_override_teacher_config_gpu_on_cpu(self):
         """Teacher cuda model can be run on cpu if specified in config"""
         # build model where teacher is specified on gpu but user overrides cpu


### PR DESCRIPTION
Summary:
We add losses in distillation by instantiating them in the distillation algorithm's init and then running them during the forward pass.

However this has some issues:
* the losses are not registered as a module in the model since they we organize them as a list of layerlossmetadata => this means that things like AMP do not behave as expected
* the losses are not on the same device as the rest of the model since they are created potentially after the model is moved to a new device

This diff solves both of these issues by including a helper function that registers and moves the losses to the same device as the model. `register_layer_losses_and_to_device` takes as input `List[LayerLossMetadata]`, moves the losses to the same device as the model and then registers these losses to the model.

Differential Revision: D41296932

