### PR TITLE
algorithm

### DIFF
--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -459,6 +459,8 @@ def _build_teacher(cfg) -> nn.Module:
         )
         runner = import_runner(cfg.DISTILLATION.TEACHER.RUNNER_NAME)()
         model = runner.build_model(teacher_cfg, eval_only=True)
+    elif cfg.DISTILLATION.TEACHER.TYPE == "no_teacher":
+        model = nn.Identity()
     else:
         raise ValueError(f"Unexpected teacher type: {cfg.DISTILLATION.TEACHER.TYPE}")
 
@@ -492,6 +494,10 @@ def _validate_teacher_config(cfg: CN) -> None:
         * torchscript_filename
     If config, needs:
         * config_fname
+
+    Bypass allowed if setting teacher.type = "no_teacher". This can be
+    useful in cases where we only have the student model
+    (e.g., domain adaptation)
     """
     if cfg.DISTILLATION.TEACHER.TYPE == "torchscript":
         assert (
@@ -501,6 +507,8 @@ def _validate_teacher_config(cfg: CN) -> None:
         assert (
             cfg.DISTILLATION.TEACHER.CONFIG_FNAME
         ), "Trying to load D2Go teacher model without config"
+    elif cfg.DISTILLATION.TEACHER.TYPE == "no_teacher":
+        pass
     else:
         raise ValueError(
             f"Unrecognized DISTILLATION.TEACHER.TYPE: {cfg.DISTILLATION.TEACHER.TYPE}"

--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -566,6 +566,13 @@ class CachedLayer(nn.Module):
         return output
 
 
+def set_cache_dict(model: nn.Module, cache: Dict) -> None:
+    """Sets the cache in all CachedLayers to input cache"""
+    for module in model.modules():
+        if isinstance(module, CachedLayer):
+            module.cache = cache
+
+
 def record_layers(model: nn.Module, layer_names: Set[str]) -> Dict[str, torch.Tensor]:
     """Save the outputs of layer_names in model
 

--- a/tests/modeling/test_modeling_distillation.py
+++ b/tests/modeling/test_modeling_distillation.py
@@ -253,6 +253,15 @@ class TestDistillation(unittest.TestCase):
             model = _build_teacher(cfg)
             self.assertEqual(gt_model.weight, model.weight)
 
+    def test_build_teacher_none(self):
+        """Check that we can ignore building the teacher"""
+        # build model
+        cfg = _get_default_cfg()
+        cfg.MODEL.META_ARCHITECTURE = "TestMetaArchAddRand"
+        cfg.DISTILLATION.TEACHER.TYPE = "no_teacher"
+        model = _build_teacher(cfg)
+        self.assertTrue(isinstance(model, nn.Module))
+
     def test_override_teacher_config_gpu_on_cpu(self):
         """Teacher cuda model can be run on cpu if specified in config"""
         # build model where teacher is specified on gpu but user overrides cpu


### PR DESCRIPTION
Summary:
Add a generic domain adaptation algorithm. This algorithm:
* gets domain0 data out of the dataloader
* runs domain0 data into the model and saves target layer output
* gets domain1 data of the dataloader
* runs domain1 data into the model and saves target layer output
* runs domain adaptation loss on domain0, domain1 outputs
* combines losses using model training iteration

This diffs adds `get_preprocess_domain0_input` and `get_preprocess_domain1_input` to the distillation helper. These are functions that the user can use to convert the dataloader output to something that will be used by the model (e.g., pull the domain0 or domain1 key out of a dataloader that returns a dict).

Differential Revision: D40970724

