### PR TITLE
set cache in recorded layers

### DIFF
--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -566,6 +566,13 @@ class CachedLayer(nn.Module):
         return output
 
 
+def set_cache_dict(model: nn.Module, cache: Dict) -> None:
+    """Sets the cache in all CachedLayers to input cache"""
+    for module in model.modules():
+        if isinstance(module, CachedLayer):
+            module.cache = cache
+
+
 def record_layers(model: nn.Module, layer_names: Set[str]) -> Dict[str, torch.Tensor]:
     """Save the outputs of layer_names in model
 


### PR DESCRIPTION
Summary:
Distillation uses a module called `CachedLayer` to record the outputs of a layer to an internal dict. This dict is typically initialized by the object itself and any value is overwritten every time the model runs.

However, sometimes we need more than one output run of the layer (e.g., domain adaptation => we run the model on real, then synthetic data and need to use both outputs).

This diff adds a helper to set externally set the cache dict of a model. In other words, we can run `set_cache_dict` on some model to change the dict used by all `CachedLayer` in the model. This allows us to run the model and record some outputs, then change the cache dict and rerun the model to save different outputs.

Differential Revision: D40970577

