### PR TITLE
support RGBA for PadToSquare and PadBorderDivisible

### DIFF
--- a/d2go/checkpoint/__init__.py
+++ b/d2go/checkpoint/__init__.py
@@ -1,3 +1,3 @@
-from .fsdp_checkpoint import FSDPCheckpointer
+from .fsdp_checkpoint import FSDPCheckpointer, FSDPPeriodicCheckpointer
 
-__all__ = ["FSDPCheckpointer"]
+__all__ = ["FSDPCheckpointer", "FSDPPeriodicCheckpointer"]

--- a/d2go/checkpoint/fsdp_checkpoint.py
+++ b/d2go/checkpoint/fsdp_checkpoint.py
@@ -59,7 +59,7 @@ class FSDPCheckpointer(QATCheckpointer):
         """
         # If no sharding, only the main process enters the saving codepath;
         # otherwise, all processes need to call state_dict() to enable state broadcasting among ranks
-        if not isinstance(self.model, FSDP) and not comm.is_main_process():
+        if not isinstance(self.model, FSDPWrapper) and not comm.is_main_process():
             return
 
         data = {}

--- a/d2go/modeling/api.py
+++ b/d2go/modeling/api.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 from d2go.config import CfgNode
 from d2go.modeling import modeling_hook as mh
 from d2go.registry.builtin import META_ARCH_REGISTRY
+from d2go.trainer.helper import parse_precision_from_string
 from d2go.utils.misc import _log_api_usage
 from detectron2.modeling import META_ARCH_REGISTRY as D2_META_ARCH_REGISTRY
 
@@ -56,6 +57,14 @@ def build_d2go_model(
 ) -> D2GoModelBuildResult:
     model = build_meta_arch(cfg)
     modeling_hooks: List[mh.ModelingHook] = []
+
+    # Cast entire model if needed
+    if cfg.SOLVER.AMP.CAST_ENTIRE_MODEL:
+        precision = parse_precision_from_string(
+            cfg.SOLVER.AMP.PRECISION, lightning=False
+        )
+        model = model.type(precision)
+
     # apply modeling hooks
     # some custom projects bypass d2go's default config so may not have the
     # MODELING_HOOKS key

--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -100,6 +100,9 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     # Profiler
     _C.PROFILERS = ["default_flop_counter"]
 
+    # Checkpointing-specific config
+    _C.LOAD_CKPT_TO_GPU = False
+
     # Add FB specific configs
     _add_detectron2go_runner_default_fb_cfg(_C)
 

--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -74,6 +74,7 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     _C.SOLVER.WEIGHT_DECAY_OVERWRITE = []
     assert not _C.SOLVER.AMP.ENABLED
     # AMP precision is used by both D2 and lightning backend. Can be "float16" or "bfloat16".
+    _C.SOLVER.AMP.CAST_ENTIRE_MODEL = True
     _C.SOLVER.AMP.PRECISION = "float16"
 
     # Betas are used in the AdamW optimizer

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -516,7 +516,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
                 _get_model_with_abnormal_checker(model),
                 data_loader,
                 optimizer,
-                grad_scaler=get_grad_scaler(cfg.FSDP.ALGORITHM),
+                grad_scaler=get_grad_scaler(cfg),
                 precision=parse_precision_from_string(
                     cfg.SOLVER.AMP.PRECISION, lightning=False
                 ),

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Type, Union
 import d2go.utils.abnormal_checker as abnormal_checker
 import detectron2.utils.comm as comm
 import torch
-from d2go.checkpoint import FSDPCheckpointer
+from d2go.checkpoint import FSDPCheckpointer, FSDPPeriodicCheckpointer
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
 from d2go.data.build import build_d2go_train_loader
@@ -496,7 +496,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
         # at the next iteration (or iter zero if there's no checkpoint).
         start_iter += 1
         max_iter = cfg.SOLVER.MAX_ITER
-        periodic_checkpointer = PeriodicCheckpointer(
+        periodic_checkpointer = FSDPPeriodicCheckpointer(
             checkpointer, cfg.SOLVER.CHECKPOINT_PERIOD, max_iter=max_iter
         )
 

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -482,6 +482,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
             cfg,
             model,
             save_dir=cfg.OUTPUT_DIR,
+            load_ckpt_to_gpu=cfg.LOAD_CKPT_TO_GPU,
             optimizer=optimizer,
             scheduler=scheduler,
         )

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -434,12 +434,6 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
         """
         results = OrderedDict()
         with maybe_subsample_n_images(cfg) as new_cfg:
-            # default model
-            cur_results = self._do_test(
-                new_cfg, model, train_iter=train_iter, model_tag="default"
-            )
-            results.update(cur_results)
-
             # model with ema weights
             if cfg.MODEL_EMA.ENABLED and not isinstance(model, PredictorWrapper):
                 logger.info("Run evaluation with EMA.")
@@ -448,6 +442,12 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
                         new_cfg, model, train_iter=train_iter, model_tag="ema"
                     )
                     results.update(cur_results)
+
+            # default model
+            cur_results = self._do_test(
+                new_cfg, model, train_iter=train_iter, model_tag="default"
+            )
+            results.update(cur_results)
 
         return results
 

--- a/d2go/trainer/fsdp.py
+++ b/d2go/trainer/fsdp.py
@@ -104,10 +104,8 @@ class FSDPWrapper(FSDP):
 
     def forward(self, *args, **kwargs):
         # Wrap forward() in autocast if mixed precision is enabled
-        if (
-            self._mixed_precision_enabled_for_params()
-            and not torch.is_autocast_enabled()
-        ):
+        # FIXME: turn off autocast if needed
+        if not torch.is_autocast_enabled():
             from torch.cuda.amp import autocast
 
             with autocast(dtype=self.precision):

--- a/d2go/trainer/fsdp.py
+++ b/d2go/trainer/fsdp.py
@@ -216,9 +216,10 @@ class FSDPModelingHook(mh.ModelingHook):
 
     def apply(self, model: nn.Module) -> FSDPWrapper:
         # SOLVER.AMP.ENABLED and SOLVER.AMP.PRECISION controls mixed precision for all parameters, buffers and reduce in FSDP
+        # FSDP mixed precision dtype has to be different from its original dtype; otherwise mixed precision should be disabled
         precision_dtype = (
             parse_precision_from_string(self.cfg.SOLVER.AMP.PRECISION, lightning=False)
-            if self.cfg.SOLVER.AMP.ENABLED
+            if self.cfg.SOLVER.AMP.ENABLED and not self.cfg.SOLVER.AMP.CAST_ENTIRE_MODEL
             else None
         )
         wrapped_model = build_fsdp(

--- a/d2go/trainer/fsdp.py
+++ b/d2go/trainer/fsdp.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+import contextlib
 import logging
 from enum import Enum
 from functools import partial
-from typing import Callable, Iterable, Optional
+from typing import Callable, Generator, Iterable, Optional
 
 import detectron2.utils.comm as comm
 import torch
@@ -20,6 +21,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
     FullStateDictConfig,
     FullyShardedDataParallel as FSDP,
     MixedPrecision,
+    LocalStateDictConfig,
     ShardingStrategy,
     StateDictType,
 )
@@ -51,8 +53,10 @@ def add_fsdp_configs(_C: CN):
     _C.FSDP.AUTO_WRAP_MIN_PARAMS = int(1e4)
     # A list of layer cls names to wrap, case sensitive
     _C.FSDP.AUTO_WRAP_LAYER_CLS = []
+    # Whether to use local state dict
+    _C.FSDP.USE_LOCAL_STATE_DICT = False
     # Whether to offload state dict to cpu
-    _C.FSDP.STATE_DICT_CPU_OFFLOAD = True
+    _C.FSDP.STATE_DICT_CPU_OFFLOAD = False
     # Whether to materialize state dict on rank 0
     _C.FSDP.STATE_DICT_RANK0_ONLY = True
 
@@ -81,22 +85,36 @@ class FSDPWrapper(FSDP):
     def __init__(
         self,
         model,
+        use_local_state_dict=False,
+        load_local_state_dict=False,
         state_dict_cpu_offload=True,
         state_dict_rank0_only=True,
         **fsdp_kwargs,
     ):
+        self.use_local_state_dict = use_local_state_dict
+        self.load_local_state_dict = load_local_state_dict
         self.offload_to_cpu = state_dict_cpu_offload
         self.rank0_only = state_dict_rank0_only
-
         super().__init__(model, **fsdp_kwargs)
 
+    @staticmethod
+    @contextlib.contextmanager
+    def state_dict_type_and_config(self, is_sharded: bool) -> Generator:
+        if is_sharded:
+            state_dict_type = StateDictType.LOCAL_STATE_DICT
+            # only offload_to_cpu=False is supported for local state dict
+            state_dict_config = LocalStateDictConfig(offload_to_cpu=False)
+        else:
+            state_dict_type = StateDictType.FULL_STATE_DICT
+            state_dict_config = FullStateDictConfig(
+                offload_to_cpu=self.offload_to_cpu, rank0_only=self.rank0_only
+            )
+        with FSDP.state_dict_type(self, state_dict_type, state_dict_config):
+            yield
+
     def state_dict(self, *args, **kwargs):
-        # TODO: support local state dict
         # NOTE: model.state_dict() needs to be called by all ranks because synchronization primitives are used
-        save_policy = FullStateDictConfig(
-            offload_to_cpu=self.offload_to_cpu, rank0_only=self.rank0_only
-        )
-        with FSDP.state_dict_type(self, StateDictType.FULL_STATE_DICT, save_policy):
+        with self.state_dict_type_and_config(self, self.use_local_state_dict):
             return super().state_dict(*args, **kwargs)
 
     def load_state_dict(
@@ -105,7 +123,7 @@ class FSDPWrapper(FSDP):
         *args,
         **kwargs,
     ):
-        with FSDP.state_dict_type(self, StateDictType.FULL_STATE_DICT):
+        with self.state_dict_type_and_config(self, self.load_local_state_dict):
             return super().load_state_dict(state_dict, *args, **kwargs)
 
 
@@ -120,6 +138,8 @@ def build_fsdp(
     param_dtype: Optional[torch.dtype] = None,
     reduce_dtype: Optional[torch.dtype] = None,
     buffer_dtype: Optional[torch.dtype] = None,
+    use_local_state_dict: bool = False,
+    load_local_state_dict: bool = False,
     state_dict_cpu_offload: bool = True,
     state_dict_rank0_only: bool = True,
     device_id: Optional[int] = None,
@@ -163,6 +183,8 @@ def build_fsdp(
         "device_id": torch.cuda.current_device() if not device_id else device_id,
     }
     wrapper_kwargs = {
+        "use_local_state_dict": use_local_state_dict,
+        "load_local_state_dict": load_local_state_dict,
         "state_dict_cpu_offload": state_dict_cpu_offload,
         "state_dict_rank0_only": state_dict_rank0_only,
     }
@@ -194,6 +216,8 @@ class FSDPModelingHook(mh.ModelingHook):
             param_dtype=precision_dtype,
             reduce_dtype=precision_dtype,
             buffer_dtype=precision_dtype,
+            use_local_state_dict=self.cfg.FSDP.USE_LOCAL_STATE_DICT,
+            load_local_state_dict=self.cfg.FSDP.USE_LOCAL_STATE_DICT,
             state_dict_cpu_offload=self.cfg.FSDP.STATE_DICT_CPU_OFFLOAD,
             state_dict_rank0_only=self.cfg.FSDP.STATE_DICT_RANK0_ONLY,
             device_id=torch.cuda.current_device(),

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -23,12 +23,13 @@ from d2go.setup import (
     setup_root_logger,
 )
 from d2go.trainer.api import TrainNetOutput
-from d2go.trainer.fsdp import create_ddp_model_with_sharding
+from d2go.trainer.fsdp import is_fsdp_enabled
 from d2go.utils.misc import (
     dump_trained_model_configs,
     print_metrics_table,
     save_binary_outputs,
 )
+from detectron2.engine.defaults import create_ddp_model
 
 
 logger = logging.getLogger("d2go.tools.train_net")
@@ -64,14 +65,22 @@ def main(
             metrics=metrics,
         )
 
-    wrapped_model = create_ddp_model_with_sharding(cfg, model)
+    # Use DDP if FSDP is not enabled
+    if not is_fsdp_enabled(cfg):
+        model = create_ddp_model(
+            model,
+            fp16_compression=cfg.MODEL.DDP_FP16_GRAD_COMPRESS,
+            device_ids=None if cfg.MODEL.DEVICE == "cpu" else [comm.get_local_rank()],
+            broadcast_buffers=False,
+            find_unused_parameters=cfg.MODEL.DDP_FIND_UNUSED_PARAMETERS,
+        )
 
-    trained_cfgs = runner.do_train(cfg, wrapped_model, resume=resume)
+    trained_cfgs = runner.do_train(cfg, model, resume=resume)
 
     final_eval = cfg.TEST.FINAL_EVAL
     if final_eval:
         # run evaluation after training in the same processes
-        metrics = runner.do_test(cfg, wrapped_model)
+        metrics = runner.do_test(cfg, model)
         print_metrics_table(metrics)
     else:
         metrics = {}


### PR DESCRIPTION
Summary:
Fix the issue related to Grey, RGB, and RBGA images
  - Support RGBA format in image transformations, such as PadToSquare.
  - Support test dataset in PadToSquare, i.e., remove assert is_train

Reviewed By: newstzpz

Differential Revision: D41592004

