### PR TITLE
temp_new_allowed

### DIFF
--- a/d2go/config/__init__.py
+++ b/d2go/config/__init__.py
@@ -11,6 +11,7 @@ from .config import (
     load_full_config_from_file,
     reroute_config_path,
     temp_defrost,
+    temp_new_allowed,
 )
 
 
@@ -22,4 +23,5 @@ __all__ = [
     "load_full_config_from_file",
     "reroute_config_path",
     "temp_defrost",
+    "temp_new_allowed",
 ]

--- a/d2go/config/config.py
+++ b/d2go/config/config.py
@@ -97,6 +97,14 @@ def temp_defrost(cfg):
 
 
 @contextlib.contextmanager
+def temp_new_allowed(cfg: CfgNode):
+    is_new_allowed = cfg.is_new_allowed()
+    cfg.set_new_allowed(True)
+    yield cfg
+    cfg.set_new_allowed(is_new_allowed)
+
+
+@contextlib.contextmanager
 def reroute_load_yaml_with_base():
     BASE_KEY = "_BASE_"
     _safe_load = yaml.safe_load

--- a/tests/misc/test_config.py
+++ b/tests/misc/test_config.py
@@ -12,6 +12,7 @@ from d2go.config import (
     CfgNode,
     load_full_config_from_file,
     reroute_config_path,
+    temp_new_allowed,
 )
 from d2go.config.utils import (
     config_dict_to_list_str,
@@ -73,6 +74,18 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(cfg.MODEL.MASK_ON, True)  # base is loaded
         self.assertEqual(cfg.MODEL.FBNET_V2.ARCH, "FBNetV3_A")  # second base is loaded
         self.assertEqual(cfg.OUTPUT_DIR, "test")  # non-base is loaded
+
+    def test_temp_new_allowed(self):
+        default_cfg = GeneralizedRCNNRunner.get_default_cfg()
+
+        def set_field(cfg):
+            cfg.THIS_BETTER_BE_A_NEW_CONFIG = 4
+
+        self.assertFalse("THIS_BETTER_BE_A_NEW_CONFIG" in default_cfg)
+        with temp_new_allowed(default_cfg):
+            set_field(default_cfg)
+        self.assertTrue("THIS_BETTER_BE_A_NEW_CONFIG" in default_cfg)
+        self.assertTrue(default_cfg.THIS_BETTER_BE_A_NEW_CONFIG == 4)
 
     def test_default_cfg_dump_and_load(self):
         default_cfg = GeneralizedRCNNRunner.get_default_cfg()


### PR DESCRIPTION
Summary:
Adding new fields to a config is only allowed if `new_allowed=True`. yacs `CfgNode` provides a `set_new_allowed(value: bool)` function.

We create a context manager like `temp_defrost` but for new_allowed to use it. We also implement unit test for the same

Reviewed By: newstzpz

Differential Revision: D41748992

