### PR TITLE
MinIoURandomCrop augmentation in d2go for detection models

### DIFF
--- a/d2go/data/dataset_mappers/d2go_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/d2go_dataset_mapper.py
@@ -104,6 +104,11 @@ class D2GoDatasetMapper(object):
             # pass additional arguments, will only be used when the Augmentation
             #   takes `annotations` as input
             inputs.annotations = dataset_dict["annotations"]
+            inputs.boxes = [
+                utils.get_bbox(obj)
+                for obj in dataset_dict["annotations"]
+                if obj.get("iscrowd", 0) == 0
+            ]
             # Crop around an instance if there are instances in the image.
             if self.crop_gen:
                 crop_tfm = utils.gen_crop_transform_with_instance(

--- a/d2go/data/transforms/d2_native.py
+++ b/d2go/data/transforms/d2_native.py
@@ -27,6 +27,7 @@ D2_RANDOM_TRANSFORMS = {
     "RandomResize": d2T.RandomResize,
     "FixedSizeCrop": d2T.FixedSizeCrop,
     "ResizeScale": d2T.ResizeScale,
+    "MinIoURandomCrop": d2T.MinIoURandomCrop,
 }
 
 
@@ -116,6 +117,13 @@ def ResizeScaleOp(
     cfg: CfgNode, arg_str: Optional[str], is_train: bool
 ) -> List[aug.Augmentation]:
     return build_func(cfg, arg_str, is_train, name="ResizeScale")
+
+
+@TRANSFORM_OP_REGISTRY.register()
+def MinIoURandomCropOp(
+    cfg: CfgNode, arg_str: Optional[str], is_train: bool
+) -> List[aug.Augmentation]:
+    return build_func(cfg, arg_str, is_train, name="MinIoURandomCrop")
 
 
 # example repr: FixedSizeCropOp::{"crop_size": [1024, 1024]}


### PR DESCRIPTION
Summary:
Add MinIoURandomCrop augmentation, passing boxes as arguments to augmentation.
Example of aug
<img width="400" alt="Screenshot 2022-12-12 at 16 49 55" src="https://user-images.githubusercontent.com/16614162/207153006-4f8be851-e9b8-40e5-8e7b-d73e7ecb1a51.png">
<img width="255" alt="Screenshot 2022-12-12 at 16 50 05" src="https://user-images.githubusercontent.com/16614162/207153014-4533127d-4e25-43eb-8d9b-0bc5f9ffb98f.png">
<img width="423" alt="Screenshot 2022-12-12 at 16 49 46" src="https://user-images.githubusercontent.com/16614162/207152987-b0eac1eb-7110-4d37-960d-e54e9e9b54b9.png">
Data overhead is around 0.04 sec

Differential Revision: D41804643

