### PR TITLE
Variable number of configurable evals

### DIFF
--- a/d2go/config/__init__.py
+++ b/d2go/config/__init__.py
@@ -5,6 +5,7 @@
 # forward the namespace to avoid `d2go.config.config`
 from .config import (
     add_cfg_nodes,
+    add_cfg_nodes_list,
     auto_scale_world_size,
     CfgNode,
     CONFIG_CUSTOM_PARSE_REGISTRY,
@@ -20,6 +21,7 @@ __all__ = [
     "CONFIG_SCALING_METHOD_REGISTRY",
     "CfgNode",
     "add_cfg_nodes",
+    "add_cfg_nodes_list",
     "auto_scale_world_size",
     "load_full_config_from_file",
     "reroute_config_path",

--- a/d2go/config/config.py
+++ b/d2go/config/config.py
@@ -193,3 +193,16 @@ def add_cfg_nodes(cfg, key: str, cfg_dict: Dict):
             add_cfg_nodes(node, k, v)
         else:
             setattr(node, k, v)
+
+
+def add_cfg_nodes_list(cfg, key: str, cfg_dicts_list: List[Dict]):
+    nodes = []
+    for cfg_dict in cfg_dicts_list:
+        node = CfgNode()
+        for k, v in cfg_dict.items():
+            if isinstance(v, dict):
+                add_cfg_nodes(node, k, v)
+            else:
+                setattr(node, k, v)
+        nodes.append(node)
+    setattr(cfg, key, nodes)


### PR DESCRIPTION
Summary: Specifying the number of evals in their parameters in .json file

Reviewed By: frogIsFine

Differential Revision: D42011116

