### PR TITLE
Convert local checkpoint to global one automatically in d2go FSDP checkpointer

### DIFF
--- a/configs/faster_rcnn_fbnetv3a_C4_FSDP.yaml
+++ b/configs/faster_rcnn_fbnetv3a_C4_FSDP.yaml
@@ -1,0 +1,27 @@
+_BASE_: "faster_rcnn_fbnetv3a_C4.yaml"
+D2GO_DATA:
+  TEST:
+    MAX_IMAGES: 50
+MODEL:
+  MODELING_HOOKS: ["FSDPModelingHook"]
+DATASETS:
+  TRAIN: ("coco_2017_val",)
+  TEST: ("coco_2017_val",)
+DATALOADER:
+  NUM_WORKERS: 0
+FSDP:
+  ALGORITHM: "full"
+  USE_LOCAL_STATE_DICT: True
+  # AUTO_WRAP_POLICY: ""
+  STATE_DICT_CPU_OFFLOAD: False
+  STATE_DICT_RANK0_ONLY: True
+SOLVER:
+  IMS_PER_BATCH: 32
+  MAX_ITER: 5
+  CHECKPOINT_PERIOD: 2
+  AMP:
+    ENABLED: False
+    PRECISION: float16
+TEST:
+  EVAL_PERIOD: 10000
+OUTPUT_DIR: /tmp/output

--- a/d2go/checkpoint/fsdp_checkpoint.py
+++ b/d2go/checkpoint/fsdp_checkpoint.py
@@ -59,7 +59,7 @@ class FSDPCheckpointer(QATCheckpointer):
         """
         # If no sharding, only the main process enters the saving codepath;
         # otherwise, all processes need to call state_dict() to enable state broadcasting among ranks
-        if not isinstance(self.model, FSDP) and not comm.is_main_process():
+        if not isinstance(self.model, FSDPWrapper) and not comm.is_main_process():
             return
 
         data = {}

--- a/d2go/checkpoint/fsdp_checkpoint.py
+++ b/d2go/checkpoint/fsdp_checkpoint.py
@@ -1,5 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 import os
+from typing import cast, IO
 
 import detectron2.utils.comm as comm
 import torch
@@ -7,6 +8,7 @@ from d2go.modeling.ema import EMAState
 
 from d2go.quantization.modeling import QATCheckpointer
 from d2go.trainer.fsdp import FSDPWrapper
+
 from torch.distributed.fsdp.fully_sharded_data_parallel import (
     FullyShardedDataParallel as FSDP,
 )
@@ -23,9 +25,17 @@ class FSDPCheckpointer(QATCheckpointer):
         Add support for loading sharded optimizer states in FSDP.
 
         .. note:: Loading optimizer states from regular checkpoints into FSDP models is currently not supported.
-            In general users should not resume regular training with FSDP.
+            In general users should not resume non-FSDP training with FSDP.
         """
         if isinstance(self.model, FSDPWrapper):
+            if path is not None:
+                # loading path is a directory: sharded local state dict is used
+                if self.path_manager.isdir(path):
+                    self.model.load_local_state_dict = True
+                    path = os.path.join(path, f"rank{comm.get_rank()}.pth")
+                # loading path is a file: full global state dict is used
+                else:
+                    self.model.load_local_state_dict = False
             checkpointables_iter = (
                 self.checkpointables.keys()
                 if checkpointables is None
@@ -40,9 +50,9 @@ class FSDPCheckpointer(QATCheckpointer):
             checkpoint = super().load(path, checkpointables=checkpointables_filtered)
             if "optimizer" in checkpointables_iter:
                 self.logger.info("Loading optimizer from {} ...".format(path))
+                optimizer = self.checkpointables["optimizer"]
                 osd = checkpoint.pop("optimizer")
-                sharded_osd = FSDP.shard_full_optim_state_dict(osd, self.model)
-                self.checkpointables["optimizer"].load_state_dict(sharded_osd)
+                scatter_optimizer_state_dict(optimizer, osd, self.model)
             if "ema_state" in checkpointables_iter:
                 self.logger.info("Loading ema_state from {} ...".format(path))
                 ema_state = checkpoint.pop("ema_state")
@@ -59,7 +69,9 @@ class FSDPCheckpointer(QATCheckpointer):
         """
         # If no sharding, only the main process enters the saving codepath;
         # otherwise, all processes need to call state_dict() to enable state broadcasting among ranks
-        if not isinstance(self.model, FSDPWrapper) and not comm.is_main_process():
+        if not isinstance(self.model, FSDPWrapper):
+            if comm.is_main_process():
+                return super().save(name, **kwargs)
             return
 
         data = {}
@@ -74,32 +86,62 @@ class FSDPCheckpointer(QATCheckpointer):
                 data[key] = obj.state_dict()
         data.update(kwargs)
 
-        # Only the main process does checkpoint saving; code copied from vision/fair/fvcore/fvcore/common/checkpoint.py
-        if comm.is_main_process():
+        # If using full state dict, only the main process does checkpoint saving; Otherwise, all processes do
+        if self.model.use_local_state_dict:
+            # Main process creates directory for local saves
+            new_save_dir = os.path.join(self.save_dir, name)
+            if comm.is_main_process():
+                if not self.path_manager.exists(new_save_dir):
+                    self.path_manager.mkdirs(new_save_dir)
+            comm.synchronize()
+            # Saving checkpoints
+            basename = "rank{}.pth".format(comm.get_rank())
+            save_file = os.path.join(new_save_dir, basename)
+            assert os.path.basename(save_file) == basename, basename
+            self._save_file(data, save_file)
+            # Main process tags last checkpoint if no errors in all processes
+            comm.synchronize()
+            if comm.is_main_process():
+                self.tag_last_checkpoint(name)
+        elif comm.is_main_process():
             basename = "{}.pth".format(name)
             save_file = os.path.join(self.save_dir, basename)
             assert os.path.basename(save_file) == basename, basename
-            self.logger.info("Saving checkpoint to {}".format(save_file))
-            with self.path_manager.open(save_file, "wb") as f:
-                # pyre-fixme[6]: For 2nd param expected `Union[PathLike[typing.Any],
-                #  IO[bytes], str, BinaryIO]` but got `Union[IO[bytes], IO[str]]`.
-                torch.save(data, f)
+            self._save_file(data, save_file)
             self.tag_last_checkpoint(basename)
 
+    def _save_file(self, data, filename):
+        self.logger.info("Saving checkpoint to {}".format(filename))
+        with self.path_manager.open(filename, "wb") as f:
+            torch.save(data, cast(IO[bytes], f))
 
-def gather_optimizer_state_dict(optimizer, model=None):
+
+def gather_optimizer_state_dict(optimizer, model: FSDPWrapper):
+    """
+    Get full/local optimizer state dict from an FSDP model.
+    """
     # FSDP: full_optim_state_dict() needs to be called by all ranks
-    if isinstance(model, FSDPWrapper):
+    if not model.use_local_state_dict:
         return FSDP.full_optim_state_dict(model, optimizer, rank0_only=model.rank0_only)
     return optimizer.state_dict()
 
 
-def gather_ema_state_dict(ema_state, model):
+def scatter_optimizer_state_dict(optimizer, optim_state_dict, model: FSDPWrapper):
     """
-    Get EMA state dict.
-    For FSDP, gather local sharded EMA states from all FSDP processes and aggregate them into a FULL GLOBAL state dict
+    Load a full/local optimizer state dict to a FSDP model.
+    If using full state dict, shard and scatter the optimizer state dict before loading
     """
-    if isinstance(model, FSDPWrapper):
+    if not model.load_local_state_dict:
+        optim_state_dict = FSDP.shard_full_optim_state_dict(optim_state_dict, model)
+    optimizer.load_state_dict(optim_state_dict)
+
+
+def gather_ema_state_dict(ema_state, model: FSDPWrapper):
+    """
+    Get full/local EMA state dict from an FSDP model.
+    If using full state dict, gather local sharded EMA states from all FSDP processes and aggregate them into a full EMA state dict
+    """
+    if not model.use_local_state_dict:
         # Apply local ema states to the model and unshard them
         with ema_state.apply_and_restore(model):
             with FSDP.summon_full_params(
@@ -110,16 +152,15 @@ def gather_ema_state_dict(ema_state, model):
             ):
                 state = EMAState.FromModel(model)
             return state.state
-    else:
-        return ema_state.state_dict()
+    return ema_state.state_dict()
 
 
-def scatter_ema_state_dict(ema_state_dict, model):
+def scatter_ema_state_dict(ema_state_dict, model: FSDPWrapper):
     """
-    Load an EMA state dict to the model.
-    EMA state represents a FULL GLOBAL state dict and needs to be properly sharded for each FSDP process to store locally
+    Load a full/local EMA state dict to a FSDP model.
+    If loading full state dict, ema_state_dict needs to be properly sharded for each FSDP process to store locally
     """
-    if isinstance(model, FSDPWrapper):
+    if not model.load_local_state_dict:
         # Store the current model state.
         old_local_state = EMAState.FromModel(model)
 

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -517,7 +517,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
                 _get_model_with_abnormal_checker(model),
                 data_loader,
                 optimizer,
-                grad_scaler=get_grad_scaler(cfg.FSDP.ALGORITHM),
+                grad_scaler=get_grad_scaler(cfg),
                 precision=parse_precision_from_string(
                     cfg.SOLVER.AMP.PRECISION, lightning=False
                 ),


### PR DESCRIPTION
Summary:
## Design
Following D41861308, local checkpoints need to be converted to global ones before  being loaded and used in non-FSDP wrapped models. This diff implements such conversion in d2go checkpointer level to allow automatic conversion with minimal user interference and no new config key.

In previous diff, `FSDPWrapper` has 2 loading modes and 2 saving modes: it uses `load_local_state_dict` to determine whether the ckpt we want to load is local or global, and uses `use_local_state_dict` to decide whether to save new ckpts as local or global. Thus, there are 4 combinations of loading/saving modes:
1. load local + save local
2. load local + save global
3. load global + save local
4. load global + save global

And the local-to-global checkpoint conversion maps to mode 2: load local + save global. Thus, when the checkpointer is in mode 2, it automatically saves the model to a global ckpt right after it loads the local ckpt. Because this happens in checkpointer level, normal training/eval can resume after ckpt conversion. This gives users a consistent and seamless experience with normal training/eval, while also providing a separate ckpt conversion feature via eval-only.

## Usage
Suppose we want to convert local checkpoint `/tmp/model_final`, user can run the same training command with extra args: `MODEL.WEIGHTS=/tmp/model_final` and `FSDP.USE_LOCAL_STATE_DICT=False`

Wiki: https://www.internalfb.com/intern/wiki/Mobile_Vision/Detectron2Go/D2 (https://github.com/facebookresearch/d2go/commit/87374efb134e539090e0b5c476809dc35bf6aedb)Go_Tutorials/Diffusion_Pipeline/Diffusion_Model_Inference/#using-checkpoints-traine

Differential Revision: D41926662

