### PR TITLE
create_toy_dataset: instance indices start at 1

### DIFF
--- a/d2go/utils/testing/data_loader_helper.py
+++ b/d2go/utils/testing/data_loader_helper.py
@@ -74,7 +74,7 @@ def create_toy_dataset(
             {
                 "image_id": i,
                 "category_id": i % num_classes,
-                "id": i,
+                "id": i + 1,
                 "bbox": bbox,
                 "keypoints": keypoints,
                 "area": width * height,


### PR DESCRIPTION
Summary: The first instance of each toy dataset was ignored when running cocoeval (null instance ids in the gt are not counted). See https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/cocoeval.py#L39

Differential Revision: D42080839

