### PR TITLE
Use parallel version of AdamW optimizer

### DIFF
--- a/d2go/optimizer/build.py
+++ b/d2go/optimizer/build.py
@@ -276,7 +276,11 @@ def adamw(cfg, model: torch.nn.Module) -> torch.optim.Optimizer:
     params = get_optimizer_param_groups(model, cfg)
 
     return maybe_add_gradient_clipping(cfg, torch.optim.AdamW)(
-        params=params, lr=cfg.SOLVER.BASE_LR, betas=cfg.SOLVER.BETAS, eps=cfg.SOLVER.EPS
+        params=params,
+        lr=cfg.SOLVER.BASE_LR,
+        betas=cfg.SOLVER.BETAS,
+        eps=cfg.SOLVER.EPS,
+        foreach=True,
     )
 
 


### PR DESCRIPTION
Summary:
Tracing d2go runners with using adamw optimizer yielded small operators being executed in the optimizer code. They can be fused together by using the foreach version.

QPS gain is ~4.5%.

Differential Revision: D42004110

