### PR TITLE
Enable tf32 by default

### DIFF
--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -526,7 +526,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
                 _get_model_with_abnormal_checker(model), data_loader, optimizer
             )
 
-        if cfg.SOLVER.AMP.ENABLED and torch.cuda.is_available():
+        if torch.cuda.is_available():
             # Allow to use the TensorFloat32 (TF32) tensor cores, available on A100 GPUs.
             # For more details https://pytorch.org/docs/stable/notes/cuda.html#tf32-on-ampere.
             torch.backends.cuda.matmul.allow_tf32 = True


### PR DESCRIPTION
Summary:
According to nvidia (https://fburl.com/bde4267e) TF32 has the same convergence-to-accuracy behavior as FP32, but is faster on A100 machines.
Enable it by default for d2go.

Differential Revision: D42312721

