### PR TITLE
pin protobuf version to 3.20.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requirements = [
     # Downgrade the protobuf package to 3.20.x or lower, related:
     # https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
     # https://github.com/protocolbuffers/protobuf/issues/10051
-    "protobuf<=3.20.1",
+    "protobuf==3.20.2",
 ]
 
 


### PR DESCRIPTION
Summary: `3.20.1` version has security issue, as https://github.com/facebookresearch/d2go/security/dependabot/1.`3.20.x+` has previously known compatibility issue, thus pin the version to `3.20.2`.

Differential Revision: D42353218

