### PR TITLE
[Reland] Clean Up MobileOptimizerType Rewrite Flags Public API and Documentation

### DIFF
--- a/d2go/export/torchscript.py
+++ b/d2go/export/torchscript.py
@@ -17,9 +17,8 @@ from detectron2.utils.file_io import PathManager
 from mobile_cv.common.misc.file_utils import make_temp_directory
 from mobile_cv.common.misc.iter_utils import recursive_iterate
 from torch import nn
-from torch._C import MobileOptimizerType
 from torch.utils.bundled_inputs import augment_model_with_bundled_inputs
-from torch.utils.mobile_optimizer import optimize_for_mobile
+from torch.utils.mobile_optimizer import MobileOptimizerType, optimize_for_mobile
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/92081

Reland of D41690203 (https://github.com/facebookresearch/d2go/commit/18de6ffb19037e8ea11057515cc3d6d966a6e799)

Remove MobileOptimizerType and all rewrite flags from torch.X and torch._C.X to clean up torch.X and torch._C.X namespaces

The affected rewrite flags are
- CONV_BN_FUSION
- FUSE_ADD_RELU
- HOIST_CONV_PACKED_PARAMS
- INSERT_FOLD_PREPACK_OPS
- REMOVE_DROPOUT
- VULKAN_AUTOMATIC_GPU_TRANSFER

Bc-Breaking Change:

Before this change, the rewrite flags were accessible through all of
1. torch.utils.mobile_optimizer.MobileOptimizerType.X
2. torch._C.MobileOptimizerType.X
3. torch.X
4. torch.MobileOptimizerType.X
5. torch._C.X

But after this change, only torch.utils.mobile_optimizer.MobileOptimizerType.X  (option 1 above) and the newly added torch._C._MobileOptimizerType.X remain

Corresponding updates to PyTorch Tutorial Docs are in https://github.com/pytorch/tutorials/pull/2163

Differential Revision: D42442395

