### PR TITLE
Moving add_cfg_nodes helper from config.py to runner.py

### DIFF
--- a/d2go/config/__init__.py
+++ b/d2go/config/__init__.py
@@ -4,7 +4,6 @@
 
 # forward the namespace to avoid `d2go.config.config`
 from .config import (
-    add_cfg_nodes,
     auto_scale_world_size,
     CfgNode,
     CONFIG_CUSTOM_PARSE_REGISTRY,
@@ -20,7 +19,6 @@ __all__ = [
     "CONFIG_CUSTOM_PARSE_REGISTRY",
     "CONFIG_SCALING_METHOD_REGISTRY",
     "CfgNode",
-    "add_cfg_nodes",
     "auto_scale_world_size",
     "load_full_config_from_file",
     "reroute_config_path",

--- a/d2go/config/config.py
+++ b/d2go/config/config.py
@@ -191,13 +191,3 @@ def load_full_config_from_file(filename: str) -> CfgNode:
     cfg = loaded_cfg.get_default_cfg()
     cfg.merge_from_other_cfg(loaded_cfg)
     return cfg
-
-
-def add_cfg_nodes(cfg, key: str, cfg_dict: Dict):
-    node = CfgNode()
-    setattr(cfg, key, node)
-    for k, v in cfg_dict.items():
-        if isinstance(v, dict):
-            add_cfg_nodes(node, k, v)
-        else:
-            setattr(node, k, v)


### PR DESCRIPTION
Summary: Moving add_cfg_nodes helper from config.py to runner.py

Reviewed By: wat3rBro

Differential Revision: D42209435

