### PR TITLE
use activation checkpoint option

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -16,6 +16,7 @@ from d2go.modeling.model_freezing_utils import add_model_freezing_configs
 from d2go.modeling.subclass import add_subclass_configs
 from d2go.quantization.modeling import add_quantization_default_configs
 from d2go.registry.builtin import CONFIG_UPDATER_REGISTRY
+from d2go.trainer.activation_checkpoint import add_activation_checkpoint_configs
 from d2go.trainer.fsdp import add_fsdp_configs
 from d2go.utils.visualization import add_tensorboard_default_configs
 from detectron2.config import get_cfg as get_d2_cfg
@@ -62,6 +63,8 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     add_distillation_configs(_C)
     # _C.FSDP
     add_fsdp_configs(_C)
+    # _C.ACTIVATION_CHECKPOINT
+    add_activation_checkpoint_configs(_C)
 
     # Set find_unused_parameters for DistributedDataParallel.
     _C.MODEL.DDP_FIND_UNUSED_PARAMETERS = False

--- a/d2go/trainer/activation_checkpoint.py
+++ b/d2go/trainer/activation_checkpoint.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+import logging
+from functools import partial
+
+import torch.nn as nn
+from d2go.config import CfgNode as CN
+from d2go.modeling import modeling_hook as mh
+from d2go.registry.builtin import MODELING_HOOK_REGISTRY
+from d2go.trainer.fsdp import get_module_class_from_name
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+    checkpoint_wrapper,
+    CheckpointImpl,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def add_activation_checkpoint_configs(_C: CN):
+    _C.ACTIVATION_CHECKPOINT = CN()
+    # A list of layer cls names to wrap, case sensitive
+    _C.ACTIVATION_CHECKPOINT.WRAP_LAYER_CLS = []
+
+
+@MODELING_HOOK_REGISTRY.register()
+class ActivationCheckpointModelingHook(mh.ModelingHook):
+    """Modeling hook that wraps model in activation checkpoint based on config"""
+
+    def apply(self, model: nn.Module) -> nn.Module:
+        logger.info("Activation Checkpointing is used")
+        non_reentrant_wrapper = partial(
+            checkpoint_wrapper,
+            checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+        )
+        layer_cls = []
+        for name in self.cfg.ACTIVATION_CHECKPOINT.WRAP_LAYER_CLS:
+            closure = get_module_class_from_name(model, name)
+            layer_cls.append(closure)
+
+        check_fn = lambda submodule: isinstance(submodule, tuple(layer_cls))
+        apply_activation_checkpointing(
+            model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=check_fn
+        )
+        return model
+
+    def unapply(self, model: nn.Module) -> nn.Module:
+        raise NotImplementedError(
+            "ActivationCheckpointModelingHook.unapply() not implemented: can't unwrap an activation checkpoint module"
+        )


### PR DESCRIPTION
Summary:
After FSDP, activation can consume more memory preventing from further increase batch size per device for higher throughput (more context: https://docs.google.com/document/d/1VhGGXicLMr-pI-BIGsWOoLjLzcPoA_hctzyi6un-8po/edit?disco=AAAAofpqHUY)

See D43072786 for an example usage

This diff applies activation checkpointing at the same granularity as FSDP wrapping.

Differential Revision: D42811308

