### PR TITLE
fix the issue of tensorboard visualization

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -137,6 +137,8 @@ def get_base_runner_default_cfg(cfg: CN) -> CN:
 
     cfg.SOLVER.AUTO_SCALING_METHODS = ["default_scale_d2_configs"]
 
+    # Frequency of metric gathering in trainer.
+    cfg.GATHER_METRIC_PERIOD = 1
     # Frequency of metric printer, tensorboard writer, etc.
     cfg.WRITER_PERIOD = 20
 

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -71,8 +71,8 @@ ALL_TB_WRITERS = []
 
 
 @lru_cache()
-def _get_tbx_writer(log_dir):
-    ret = TensorboardXWriter(log_dir)
+def _get_tbx_writer(log_dir, window_size=20):
+    ret = TensorboardXWriter(log_dir, window_size=window_size)
     ALL_TB_WRITERS.append(ret)
     return ret
 
@@ -236,7 +236,9 @@ class D2GoDataAPIMixIn:
 
     @classmethod
     def get_tbx_writer(cls, cfg):
-        return _get_tbx_writer(get_tensorboard_log_dir(cfg.OUTPUT_DIR))
+        return _get_tbx_writer(
+            get_tensorboard_log_dir(cfg.OUTPUT_DIR), window_size=cfg.get("WRITER_PERIOD", 20)
+        )
 
     @staticmethod
     def get_data_loader_vis_wrapper() -> Optional[Type[DataLoaderVisWrapper]]:
@@ -528,6 +530,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
                 _get_model_with_abnormal_checker(model),
                 data_loader,
                 optimizer,
+                gather_metric_period=cfg.GATHER_METRIC_PERIOD,
                 grad_scaler=get_grad_scaler(cfg),
                 precision=parse_precision_from_string(
                     cfg.SOLVER.AMP.PRECISION, lightning=False
@@ -535,7 +538,10 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
             )
         else:
             trainer = SimpleTrainer(
-                _get_model_with_abnormal_checker(model), data_loader, optimizer
+                _get_model_with_abnormal_checker(model),
+                data_loader,
+                optimizer,
+                gather_metric_period=cfg.GATHER_METRIC_PERIOD,
             )
 
         if cfg.SOLVER.AMP.ENABLED and torch.cuda.is_available():
@@ -549,10 +555,17 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
         )
 
         if comm.is_main_process():
+            assert (
+                cfg.GATHER_METRIC_PERIOD <= cfg.WRITER_PERIOD
+                and cfg.WRITER_PERIOD % cfg.GATHER_METRIC_PERIOD == 0
+            ), "WRITER_PERIOD needs to be divisible by GATHER_METRIC_PERIOD"
             tbx_writer = self.get_tbx_writer(cfg)
             writers = [
-                CommonMetricPrinter(max_iter),
-                JSONWriter(os.path.join(cfg.OUTPUT_DIR, "metrics.json")),
+                CommonMetricPrinter(max_iter, window_size=cfg.WRITER_PERIOD),
+                JSONWriter(
+                    os.path.join(cfg.OUTPUT_DIR, "metrics.json"),
+                    window_size=cfg.WRITER_PERIOD,
+                ),
                 tbx_writer,
             ]
             trainer_hooks.append(hooks.PeriodicWriter(writers, cfg.WRITER_PERIOD))


### PR DESCRIPTION
Summary:
As shown in the attached image and tb visualization, some of our jobs fail to save the results to tensorboard.
There should be some messages between circled lines of the screenshot if the images are added to tensorboard.
One possible reason is that the tensorbord visualization evaluator is only added for the rank 0 gpu. It may fail to fetch any data during evaluation of diffusion model which only do 1 batch of inference during validataion.
To resolve this issue, we add the visualization evaluator to all ranks of gpus and gather their results, and finally add the results with biggest batchsize to the tensorboard for visualization.

The screenshot is from f410204704 (https://www.internalfb.com/manifold/explorer/mobile_vision_workflows/tree/workflows/xutao/20230211/latest_train/dalle2_decoder.SIULDLpgix/e2e_train/log.txt)

Differential Revision: D43263543

