### PR TITLE
add correctness test for ai infra checkpointer with FSDP local mode in d2go runner

### DIFF
--- a/d2go/distributed.py
+++ b/d2go/distributed.py
@@ -27,6 +27,7 @@ from mobile_cv.torch.utils_pytorch.distributed_helper import (
     DistributedParams,
     enable_dist_process_groups,
     launch as _launch,
+    launch_deco as _launch_deco,
     save_return_deco,
 )
 
@@ -77,6 +78,13 @@ def distributed_worker(
         # Now the D2's comm module should be fully functional
         deco = save_return_deco(return_save_file, dist_params.global_rank)
         return deco(main_func)(*args, **kwargs)
+
+
+def launch_deco(**kwargs):
+    """
+    launch_deco for d2go distributed worker
+    """
+    return _launch_deco(launcher=launch, **kwargs)
 
 
 def launch(


### PR DESCRIPTION
Summary:
This diff adds a correctness test for ai infra checkpointer + FSDP local mode within a d2go runner. It verifies that ai infra checkpointer saves the exact same model as the old checkpointer, and that we can convert between ai infra checkpoints (local) and fsdp checkpoints (local + global) seamlessly.

Note: adapted from mattcyu1's script D43492498.

## Testing

Testing is done by saving with both ai infra and fsdp checkponter and compare the state dict produced. Here are the steps:

1. Build the model. Save a local ckpt using the FSDP checkpointer and another local ckpt using the AIInfra checkpointer
2. Reset the model. Load local ckpt using the FSDP checkpointer and convert it to global ckpt
3. Reset the model. Load local ckpt using the AIInfra checkpointer and re-save it as global ckpt using the FSDP checkpointer
4. Compare the two global state dicts

## Others

1. Add a launch decorator for d2go.distributed worker using the one in `fbcode/mobile-vision/mobile_cv/mobile_cv/torch/utils_pytorch/distributed_helper.py`

2. Modify how EMA resets state when load_state_dict is called. This is needed because ai infra checkpointer loads state dict in place before ema.load_state_dict() is called. Thus, when ema tries to load itself, calling self.state.clear() will delete the input state_dict, causing ema to reset to an empty dict

Reviewed By: xunnanxu

Differential Revision: D43423572

