### PR TITLE
Docs: --output-dir ./ should follow --predictor-type in d2go.exporter

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -49,7 +49,7 @@ MODEL.WEIGHTS https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/246823121
 
 ```bash
 d2go.exporter --config-file configs/faster_rcnn_fbnetv3a_C4.yaml \
---output-dir ./ --predictor-type torchscript_int8 \
+--predictor-type torchscript_int8 --output-dir ./ \
 MODEL.WEIGHTS https://mobile-cv.s3-us-west-2.amazonaws.com/d2go/models/246823121/model_0479999.pth
 ```
 


### PR DESCRIPTION
Correction in docs.
Related issue: https://github.com/facebookresearch/d2go/issues/514
