### PR TITLE
Run zoomer profiling

### DIFF
--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -385,7 +385,8 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
             )
 
         attach_profilers(cfg, model)
-        prepare_fb_model_for_eval(cfg, model)
+        if is_final:
+            prepare_fb_model_for_eval(cfg, model)
 
         results = OrderedDict()
         results[model_tag] = OrderedDict()


### PR DESCRIPTION
Summary: Enable profiling for eval step only, not on every eval (which can be called during training)

Differential Revision: D44535915

