### PR TITLE
Set the default logging level to info

### DIFF
--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -28,6 +28,7 @@ from d2go.distributed import (
 from d2go.runner import BaseRunner, DefaultTask, import_runner, RunnerV2Mixin
 from d2go.utils.helper import run_once
 from d2go.utils.launch_environment import get_launch_environment
+from d2go.utils.logging import initialize_logging
 from detectron2.utils.collect_env import collect_env_info
 from detectron2.utils.file_io import PathManager
 from detectron2.utils.logger import setup_logger as _setup_logger
@@ -48,8 +49,7 @@ def setup_root_logger(logging_level: int = logging.DEBUG) -> None:
     See https://docs.python.org/3/library/logging.html for a more in-depth
     description
     """
-    root_logger = logging.getLogger()
-    root_logger.setLevel(logging_level)
+    initialize_logging(logging_level)
     _replace_print_with_logging()
 
 
@@ -342,11 +342,9 @@ def setup_logger(
         color=color,
         name=module_name,
         abbrev_name=abbrev_name,
+        enable_propagation=True,
+        configure_stdout=False,
     )
-
-    # NOTE: the root logger might has been configured by other applications,
-    # since this already sub-top level, just don't propagate to root.
-    logger.propagate = False
 
     return logger
 

--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -38,7 +38,7 @@ from mobile_cv.common.misc.py import FolderLock, MultiprocessingPdb, post_mortem
 logger = logging.getLogger(__name__)
 
 
-def setup_root_logger(logging_level: int = logging.DEBUG) -> None:
+def setup_root_logger(logging_level: int = logging.INFO) -> None:
     """
     Sets up the D2Go root logger. When a new logger is created, it lies in a tree.
     If the logger being used does not have a specific level being specified, it

--- a/d2go/utils/logging.py
+++ b/d2go/utils/logging.py
@@ -1,0 +1,11 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import logging
+
+from mobile_cv.common.misc.oss_utils import fb_overwritable
+
+
+@fb_overwritable()
+def initialize_logging(logging_level: int) -> None:
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging_level)


### PR DESCRIPTION
Summary: Further along the setup, D2Go loggers will have logging level set to debug. Setting logging level as debug for every process introduces unnecessary logs.

Differential Revision: D44561105

