### PR TITLE
Set gradient as bucket view

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -118,6 +118,9 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     # Specify whether to perform NUMA binding
     _C.NUMA_BINDING = False
 
+    # Specify whether to zero the gradients before forward
+    _C.ZERO_GRAD_BEFORE_FORWARD = False
+
 
 def _add_rcnn_default_config(_C: CN) -> None:
     _C.EXPORT_CAFFE2 = CN()

--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -72,6 +72,8 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     _C.MODEL.DDP_FIND_UNUSED_PARAMETERS = False
     # Set FP16 gradient compression for DistributedDataParallel.
     _C.MODEL.DDP_FP16_GRAD_COMPRESS = False
+    # Specify the gradients as views
+    _C.MODEL.DDP_GRADIENT_AS_BUCKET_VIEW = False
 
     # Set default optimizer
     _C.SOLVER.OPTIMIZER = "sgd"

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -548,6 +548,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
                 data_loader,
                 optimizer,
                 gather_metric_period=cfg.GATHER_METRIC_PERIOD,
+                zero_grad_before_forward=cfg.ZERO_GRAD_BEFORE_FORWARD,
                 grad_scaler=get_grad_scaler(cfg),
                 precision=parse_precision_from_string(
                     cfg.SOLVER.AMP.PRECISION, lightning=False
@@ -560,6 +561,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
                 data_loader,
                 optimizer,
                 gather_metric_period=cfg.GATHER_METRIC_PERIOD,
+                zero_grad_before_forward=cfg.ZERO_GRAD_BEFORE_FORWARD,
             )
 
         if cfg.SOLVER.AMP.ENABLED and torch.cuda.is_available():

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -93,6 +93,7 @@ def main(
                 else [comm.get_local_rank()],
                 broadcast_buffers=False,
                 find_unused_parameters=cfg.MODEL.DDP_FIND_UNUSED_PARAMETERS,
+                gradient_as_bucket_view=cfg.MODEL.DDP_GRADIENT_AS_BUCKET_VIEW,
             )
 
         logger.info("Starting train..")


### PR DESCRIPTION
Summary: Add a config variable: DDP_GRADIENT_AS_BUCKET_VIEW. Pass it to DDP. This variable reduces the memory consumption of the model.

Reviewed By: tglik

Differential Revision: D44273339

