### PR TITLE
Replace hasattr with getattr in mobile-vision/d2go/d2go/utils/abnormal_checker.py

### DIFF
--- a/d2go/utils/abnormal_checker.py
+++ b/d2go/utils/abnormal_checker.py
@@ -111,7 +111,7 @@ class AbnormalLossChecker(object):
         all_info = {
             "losses": losses,
             "data": data,
-            "model": model.module if hasattr(model, "module") else model,
+            "model": getattr(model, "module", model),
             "prev_loss": self.prev_loss,
             "step": self.prev_index + 1,
         }


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Differential Revision: D44886687

