### PR TITLE
Add logging for checkpointer type, distributed mode, and checkpointing mode in d2go

### DIFF
--- a/d2go/utils/misc.py
+++ b/d2go/utils/misc.py
@@ -129,6 +129,14 @@ def _log_api_usage(identifier: str):
     torch._C._log_api_usage_once("d2go." + identifier)
 
 
+def _log_api_usage_on_main_process(identifier: str):
+    """
+    Log the usage of d2go API only on the main process.
+    """
+    if comm.is_main_process():
+        _log_api_usage(identifier)
+
+
 def inplace_delegate(
     self,
     api_name: str,


### PR DESCRIPTION
Summary:
Currently, d2go supports 2 checkpointers, 2 distributed modes and 3 checkpointing modes. The many options make it hard to maintain and manage all use cases. For example, after the recent migration to FSDP sharded_state_dict, it's hard to understand and trace down the usage of the deprecated version.

Per crassirostris and wat3rBro's advice, this diff add API loggings to better keep track of checkpointer usage in d2go.

## Appendix
2 checkpointers: FSDPCheckpointer, AIInfraCheckpointer
2 distributed modes: ddp, fsdp
3 checkpointing modes (fsdp only): local_state_dict, sharded_state_dict, full_state_dict

Reviewed By: tglik

Differential Revision: D45385021

