### PR TITLE
Expand relative imports to absolute versions

### DIFF
--- a/d2go/checkpoint/__init__.py
+++ b/d2go/checkpoint/__init__.py
@@ -1,5 +1,5 @@
-from .api import is_distributed_checkpoint
-from .fsdp_checkpoint import FSDPCheckpointer
+from d2go.checkpoint.api import is_distributed_checkpoint
+from d2go.checkpoint.fsdp_checkpoint import FSDPCheckpointer
 
 __all__ = [
     "is_distributed_checkpoint",

--- a/d2go/config/__init__.py
+++ b/d2go/config/__init__.py
@@ -3,7 +3,7 @@
 
 
 # forward the namespace to avoid `d2go.config.config`
-from .config import (
+from d2go.config.config import (
     auto_scale_world_size,
     CfgNode,
     CONFIG_CUSTOM_PARSE_REGISTRY,

--- a/d2go/config/config.py
+++ b/d2go/config/config.py
@@ -8,10 +8,9 @@ from typing import List
 
 import mock
 import yaml
+from d2go.config.utils import reroute_config_path, resolve_default_config
 from detectron2.config import CfgNode as _CfgNode
 from fvcore.common.registry import Registry
-
-from .utils import reroute_config_path, resolve_default_config
 
 logger = logging.getLogger(__name__)
 

--- a/d2go/data/dataset_mappers/__init__.py
+++ b/d2go/data/dataset_mappers/__init__.py
@@ -2,7 +2,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-# @fb-only: from . import fb  # isort:skip  # noqa 
-from .build import build_dataset_mapper, D2GO_DATA_MAPPER_REGISTRY  # noqa
-from .d2go_dataset_mapper import D2GoDatasetMapper  # noqa
-from .rotated_dataset_mapper import RotatedDatasetMapper  # noqa
+# @fb-only: from d2go.data.dataset_mappers import fb  # isort:skip  # noqa 
+from d2go.data.dataset_mappers.build import (  # noqa
+    build_dataset_mapper,
+    D2GO_DATA_MAPPER_REGISTRY,
+)
+from d2go.data.dataset_mappers.d2go_dataset_mapper import D2GoDatasetMapper  # noqa
+from d2go.data.dataset_mappers.rotated_dataset_mapper import (  # noqa
+    RotatedDatasetMapper,
+)

--- a/d2go/data/dataset_mappers/d2go_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/d2go_dataset_mapper.py
@@ -7,6 +7,7 @@ import logging
 
 import numpy as np
 import torch
+from d2go.data.dataset_mappers.build import D2GO_DATA_MAPPER_REGISTRY
 from d2go.data.dataset_mappers.data_reading import (
     read_image_with_prefetch,
     read_sem_seg_file_with_prefetch,
@@ -14,8 +15,6 @@ from d2go.data.dataset_mappers.data_reading import (
 from d2go.utils.helper import retryable
 from detectron2.data import detection_utils as utils, transforms as T
 from detectron2.data.transforms.augmentation import AugInput, AugmentationList
-
-from .build import D2GO_DATA_MAPPER_REGISTRY
 
 logger = logging.getLogger(__name__)
 

--- a/d2go/data/dataset_mappers/rotated_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/rotated_dataset_mapper.py
@@ -7,11 +7,10 @@ import logging
 
 import numpy as np
 import torch
+from d2go.data.dataset_mappers.build import D2GO_DATA_MAPPER_REGISTRY
 from d2go.data.dataset_mappers.d2go_dataset_mapper import D2GoDatasetMapper
 from detectron2.data import detection_utils as utils, transforms as T
 from detectron2.structures import BoxMode, Instances, RotatedBoxes
-
-from .build import D2GO_DATA_MAPPER_REGISTRY
 
 
 logger = logging.getLogger(__name__)

--- a/d2go/data/datasets.py
+++ b/d2go/data/datasets.py
@@ -8,14 +8,13 @@ import logging
 import os
 from collections import namedtuple
 
+from d2go.data.extended_coco import coco_text_load, extended_coco_load
+from d2go.data.extended_lvis import extended_lvis_load
+from d2go.data.keypoint_metadata_registry import get_keypoint_metadata
 from d2go.utils.helper import get_dir_path
 from detectron2.data import DatasetCatalog, MetadataCatalog
 from detectron2.utils.registry import Registry
 from mobile_cv.common.misc.oss_utils import fb_overwritable
-
-from .extended_coco import coco_text_load, extended_coco_load
-from .extended_lvis import extended_lvis_load
-from .keypoint_metadata_registry import get_keypoint_metadata
 
 
 logger = logging.getLogger(__name__)

--- a/d2go/data/extended_coco.py
+++ b/d2go/data/extended_coco.py
@@ -11,12 +11,11 @@ from collections import defaultdict
 from typing import Callable, Dict, List, Optional
 
 import detectron2.utils.comm as comm
+from d2go.data.cache_util import _cache_json_file
 from detectron2.data import MetadataCatalog
 from detectron2.structures import BoxMode
 from detectron2.utils.file_io import PathManager
 from pycocotools.coco import COCO
-
-from .cache_util import _cache_json_file
 
 
 logger = logging.getLogger(__name__)

--- a/d2go/data/extended_lvis.py
+++ b/d2go/data/extended_lvis.py
@@ -5,11 +5,10 @@
 import logging
 import os
 
+from d2go.data.extended_coco import _cache_json_file
 from detectron2.data import MetadataCatalog
 from detectron2.structures import BoxMode
 from fvcore.common.timer import Timer
-
-from .extended_coco import _cache_json_file
 
 """
 This file contains functions to parse LVIS-format annotations into dicts in the

--- a/d2go/data/transforms/__init__.py
+++ b/d2go/data/transforms/__init__.py
@@ -3,5 +3,13 @@
 
 
 # import all modules to make sure Registry works
-# @fb-only: from . import fb  # isort:skip  # noqa 
-from . import affine, auto_aug, blur, box_utils, color_yuv, crop, d2_native  # noqa
+# @fb-only: from d2go.data.transforms import fb  # isort:skip  # noqa 
+from d2go.data.transforms import (  # noqa
+    affine,
+    auto_aug,
+    blur,
+    box_utils,
+    color_yuv,
+    crop,
+    d2_native,
+)

--- a/d2go/data/transforms/affine.py
+++ b/d2go/data/transforms/affine.py
@@ -9,10 +9,11 @@ from typing import List, Optional, Tuple
 import cv2
 import numpy as np
 import torchvision.transforms as T
+from d2go.data.transforms.build import TRANSFORM_OP_REGISTRY
 from detectron2.config import CfgNode
-from detectron2.data.transforms import NoOpTransform, Transform, TransformGen
 
-from .build import TRANSFORM_OP_REGISTRY
+from detectron2.data.transforms.augmentation import TransformGen
+from fvcore.transforms.transform import NoOpTransform, Transform
 
 
 class AffineTransform(Transform):

--- a/d2go/data/transforms/auto_aug.py
+++ b/d2go/data/transforms/auto_aug.py
@@ -7,11 +7,11 @@ from typing import List, Optional, Union
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
 import torchvision.transforms as tvtf
+
+from d2go.data.transforms.build import _json_load, TRANSFORM_OP_REGISTRY
 from d2go.data.transforms.tensor import Array2Tensor, Tensor2Array
 from detectron2.config import CfgNode
 from fvcore.transforms.transform import Transform
-
-from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 class ToTensorWrapper:

--- a/d2go/data/transforms/blur.py
+++ b/d2go/data/transforms/blur.py
@@ -8,10 +8,10 @@ import cv2
 import detectron2.data.transforms.augmentation as aug
 
 import numpy as np
+from d2go.data.transforms.build import _json_load, TRANSFORM_OP_REGISTRY
 from detectron2.config import CfgNode
-from detectron2.data.transforms import NoOpTransform, Transform
 
-from .build import _json_load, TRANSFORM_OP_REGISTRY
+from fvcore.transforms.transform import NoOpTransform, Transform
 
 
 class LocalizedBoxMotionBlurTransform(Transform):

--- a/d2go/data/transforms/box_utils.py
+++ b/d2go/data/transforms/box_utils.py
@@ -7,11 +7,10 @@ from typing import Any, List, Tuple, Union
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
 import torch
+from d2go.data.transforms.build import _json_load, TRANSFORM_OP_REGISTRY
 from detectron2.config import CfgNode
 from detectron2.data.transforms.transform import Transform
 from detectron2.structures.boxes import Boxes
-
-from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 def get_box_union(boxes: Boxes):

--- a/d2go/data/transforms/color_yuv.py
+++ b/d2go/data/transforms/color_yuv.py
@@ -6,12 +6,11 @@ from typing import Callable, List, Union
 
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
+from d2go.data.transforms.build import _json_load, TRANSFORM_OP_REGISTRY
 from detectron2.config import CfgNode
 from detectron2.data import detection_utils as du
 from detectron2.data.transforms.transform import Transform
 from fvcore.transforms.transform import BlendTransform
-
-from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 class InvertibleColorTransform(Transform):

--- a/d2go/data/transforms/crop.py
+++ b/d2go/data/transforms/crop.py
@@ -5,15 +5,14 @@
 import math
 from typing import Any, List, Optional, Tuple, Union
 
+import d2go.data.transforms.box_utils as bu
 import detectron2.data.transforms.augmentation as aug
 import numpy as np
+from d2go.data.transforms.build import _json_load, TRANSFORM_OP_REGISTRY
 from detectron2.config import CfgNode
-from detectron2.data.transforms import ExtentTransform
+from detectron2.data.transforms.transform import ExtentTransform
 from detectron2.structures import BoxMode
 from fvcore.transforms.transform import CropTransform, NoOpTransform, Transform
-
-from . import box_utils as bu
-from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 
 class CropBoundary(aug.Augmentation):

--- a/d2go/data/transforms/d2_native.py
+++ b/d2go/data/transforms/d2_native.py
@@ -6,11 +6,10 @@ import logging
 from typing import List, Optional, Union
 
 import detectron2.data.transforms.augmentation as aug
+from d2go.data.transforms.build import _json_load, TRANSFORM_OP_REGISTRY
 from detectron2.config import CfgNode
 from detectron2.data import transforms as d2T
 from detectron2.projects.point_rend import ColorAugSSDTransform
-
-from .build import _json_load, TRANSFORM_OP_REGISTRY
 
 logger = logging.getLogger(__name__)
 

--- a/d2go/evaluation/__init__.py
+++ b/d2go/evaluation/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-# @fb-only: from . import fb  # noqa 
-from .prediction_count_evaluation import PredictionCountEvaluator  # noqa
+# @fb-only: from d2go.evaluation import fb  # noqa 
+from d2go.evaluation.prediction_count_evaluation import PredictionCountEvaluator  # noqa
 
 __all__ = [k for k in globals().keys() if not k.startswith("_")]

--- a/d2go/export/__init__.py
+++ b/d2go/export/__init__.py
@@ -2,4 +2,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 # enable registry
-from . import torchscript  # noqa
+from d2go.export import torchscript  # noqa

--- a/d2go/modeling/__init__.py
+++ b/d2go/modeling/__init__.py
@@ -3,4 +3,4 @@
 
 
 # NOTE: making necessary imports to register with Registery
-from . import backbone, meta_arch, modeldef  # noqa  # noqa  # noqa
+from d2go.modeling import backbone, meta_arch, modeldef  # noqa  # noqa  # noqa

--- a/d2go/modeling/backbone/__init__.py
+++ b/d2go/modeling/backbone/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-# @fb-only: from . import fb, fbnet_v2  # noqa 
+# @fb-only: from d2go.modeling.backbone import fb, fbnet_v2  # noqa 
 
 
 # Explicitly expose all registry-based modules

--- a/d2go/modeling/backbone/fbnet_v2.py
+++ b/d2go/modeling/backbone/fbnet_v2.py
@@ -9,6 +9,14 @@ from typing import List
 
 import torch
 import torch.nn as nn
+from d2go.modeling.backbone.modules import (
+    KeypointRCNNConvUpsamplePredictorNoUpscale,
+    KeypointRCNNIRFPredictorNoUpscale,
+    KeypointRCNNPredictor,
+    KeypointRCNNPredictorNoUpscale,
+    MaskRCNNConv1x1Predictor,
+    RPNHeadConvRegressor,
+)
 from d2go.modeling.modeldef.fbnet_modeldef_registry import FBNetV2ModelArch
 from detectron2.layers import ShapeSpec
 from detectron2.modeling import (
@@ -22,15 +30,6 @@ from detectron2.modeling.roi_heads import box_head, keypoint_head, mask_head
 from detectron2.utils.logger import log_first_n
 from mobile_cv.arch.fbnet_v2 import fbnet_builder as mbuilder
 from mobile_cv.arch.utils.helper import format_dict_expanding_list_values
-
-from .modules import (
-    KeypointRCNNConvUpsamplePredictorNoUpscale,
-    KeypointRCNNIRFPredictorNoUpscale,
-    KeypointRCNNPredictor,
-    KeypointRCNNPredictorNoUpscale,
-    MaskRCNNConv1x1Predictor,
-    RPNHeadConvRegressor,
-)
 
 
 logger = logging.getLogger(__name__)

--- a/d2go/modeling/meta_arch/__init__.py
+++ b/d2go/modeling/meta_arch/__init__.py
@@ -2,5 +2,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 # NOTE: making necessary imports to register with Registry
-# @fb-only: from . import fb  # isort:skip  # noqa 
-from . import fcos, panoptic_fpn, rcnn, retinanet, semantic_seg  # noqa
+# @fb-only: from d2go.modeling.meta_arch import fb  # isort:skip  # noqa 
+from d2go.modeling.meta_arch import (  # noqa
+    fcos,
+    panoptic_fpn,
+    rcnn,
+    retinanet,
+    semantic_seg,
+)

--- a/d2go/modeling/modeldef/__init__.py
+++ b/d2go/modeling/modeldef/__init__.py
@@ -6,5 +6,5 @@
 This is the centralized place to define modeldef for all projects under D2Go.
 """
 
-# @fb-only: from . import fb  # isort:skip  # noqa 
-from . import modeldef  # noqa
+# @fb-only: from d2go.modeling.modeldef import fb  # isort:skip  # noqa 
+from d2go.modeling import modeldef  # noqa

--- a/d2go/optimizer/__init__.py
+++ b/d2go/optimizer/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from .build import build_optimizer_mapper
+from d2go.optimizer.build import build_optimizer_mapper
 
 __all__ = ["build_optimizer_mapper"]

--- a/d2go/quantization/modeling.py
+++ b/d2go/quantization/modeling.py
@@ -10,15 +10,17 @@ from typing import Tuple
 import detectron2.utils.comm as comm
 import torch
 from d2go.quantization import learnable_qat
+from d2go.quantization.fx import get_convert_fx_fn, get_prepare_fx_fn
+from d2go.quantization.qconfig import (
+    set_backend_and_create_qconfig,
+    smart_decode_backend,
+)
 from detectron2.checkpoint import DetectionCheckpointer
-from detectron2.engine import HookBase, SimpleTrainer
+from detectron2.engine.train_loop import HookBase, SimpleTrainer
 from detectron2.utils.file_io import PathManager
 from mobile_cv.arch.quantization.observer import update_stat as observer_update_stat
 from mobile_cv.arch.utils import fuse_utils
 from mobile_cv.common.misc.iter_utils import recursive_iterate
-
-from .fx import get_convert_fx_fn, get_prepare_fx_fn
-from .qconfig import set_backend_and_create_qconfig, smart_decode_backend
 
 TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
 if TORCH_VERSION > (1, 10):

--- a/d2go/runner/__init__.py
+++ b/d2go/runner/__init__.py
@@ -5,11 +5,14 @@
 import importlib
 from typing import Optional, Type, Union
 
-from .api import RunnerV2Mixin
-from .default_runner import BaseRunner, Detectron2GoRunner, GeneralizedRCNNRunner
-from .lightning_task import DefaultTask
-from .training_hooks import TRAINER_HOOKS_REGISTRY
-
+from d2go.runner.api import RunnerV2Mixin
+from d2go.runner.default_runner import (
+    BaseRunner,
+    Detectron2GoRunner,
+    GeneralizedRCNNRunner,
+)
+from d2go.runner.lightning_task import DefaultTask
+from d2go.runner.training_hooks import TRAINER_HOOKS_REGISTRY
 
 __all__ = [
     "RunnerV2Mixin",

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -54,7 +54,8 @@ from detectron2.data import (
     build_detection_train_loader as d2_build_detection_train_loader,
     MetadataCatalog,
 )
-from detectron2.engine import AMPTrainer, hooks, SimpleTrainer
+from detectron2.engine import hooks
+from detectron2.engine.train_loop import AMPTrainer, SimpleTrainer
 from detectron2.evaluation import (
     COCOEvaluator,
     DatasetEvaluators,

--- a/d2go/runner/training_hooks.py
+++ b/d2go/runner/training_hooks.py
@@ -7,7 +7,7 @@ from d2go.config import CfgNode
 
 from d2go.utils.gpu_memory_profiler import log_memory_snapshot, record_memory_history
 
-from detectron2.engine import HookBase
+from detectron2.engine.train_loop import HookBase
 from detectron2.utils.registry import Registry
 
 

--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -23,7 +23,8 @@ from d2go.distributed import (
     get_local_rank,
     get_num_processes_per_machine,
 )
-from d2go.runner import BaseRunner, DefaultTask, import_runner, RunnerV2Mixin
+from d2go.runner import BaseRunner, import_runner, RunnerV2Mixin
+from d2go.runner.lightning_task import DefaultTask
 from d2go.utils.helper import run_once
 from d2go.utils.launch_environment import get_launch_environment
 from d2go.utils.logging import initialize_logging, replace_print_with_logging

--- a/d2go/utils/__init__.py
+++ b/d2go/utils/__init__.py
@@ -4,5 +4,5 @@
 
 # import to make sure Registry works
 # usort does not respect the `fb-only` tag so use isort:skip here
-# @fb-only: from . import fb  # isort:skip  # noqa 
-from . import flop_calculator  # noqa
+# @fb-only: from d2go.utils import fb  # isort:skip  # noqa 
+from d2go.utils import flop_calculator  # noqa

--- a/d2go/utils/misc.py
+++ b/d2go/utils/misc.py
@@ -12,10 +12,9 @@ from typing import Any, Callable, Dict, Iterator, Optional
 import detectron2.utils.comm as comm
 import torch
 from d2go.config import CfgNode
+from d2go.utils.tensorboard_log_util import get_tensorboard_log_dir  # noqa: forwarding
 from detectron2.utils.file_io import PathManager
 from tabulate import tabulate
-
-from .tensorboard_log_util import get_tensorboard_log_dir  # noqa: forwarding
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Summary: Expanding the relative imports to absolute ones helps the autodeps down the stack.

Reviewed By: tglik

Differential Revision: D45912074

