### PR TITLE
Optimizer: create a separate buck target

### DIFF
--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -28,7 +28,7 @@ from d2go.evaluation.evaluator import inference_on_dataset
 from d2go.modeling import ema, kmeans_anchors
 from d2go.modeling.api import build_d2go_model
 from d2go.modeling.model_freezing_utils import freeze_matched_bn, set_requires_grad
-from d2go.optimizer import build_optimizer_mapper
+from d2go.optimizer.build import build_optimizer_mapper
 from d2go.quantization.modeling import QATHook, setup_qat_model
 from d2go.runner.config_defaults import (
     get_base_runner_default_cfg,

--- a/d2go/runner/lightning_task.py
+++ b/d2go/runner/lightning_task.py
@@ -14,7 +14,7 @@ from d2go.data.datasets import inject_coco_datasets, register_dynamic_datasets
 from d2go.data.utils import update_cfg_if_using_adhoc_dataset
 from d2go.modeling.api import build_meta_arch
 from d2go.modeling.model_freezing_utils import set_requires_grad
-from d2go.optimizer import build_optimizer_mapper
+from d2go.optimizer.build import build_optimizer_mapper
 from d2go.runner.api import RunnerV2Mixin
 from d2go.runner.callbacks.quantization import maybe_prepare_for_quantization, PREPARED
 from d2go.runner.default_runner import (

--- a/tests/modeling/test_optimizer.py
+++ b/tests/modeling/test_optimizer.py
@@ -7,7 +7,7 @@ import unittest
 
 import d2go.runner.default_runner as default_runner
 import torch
-from d2go.optimizer import build_optimizer_mapper
+from d2go.optimizer.build import build_optimizer_mapper
 from d2go.utils.testing import helper
 
 


### PR DESCRIPTION
Summary:
Create buck target for the optimizer.
Other than creating TARGETS, replaced `from d2go.optimizer import build_optimizer_mapper` with `from d2go.optimizer.build import build_optimizer_mapper`

Reviewed By: tglik

Differential Revision: D45912075

