### PR TITLE
Quantization: create a separate buck target

### DIFF
--- a/d2go/quantization/qconfig.py
+++ b/d2go/quantization/qconfig.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
 import torch
-from d2go.quantization import learnable_qat
+from d2go.quantization.learnable_qat import convert_to_learnable_qconfig
 from mobile_cv.common.misc.registry import Registry
 
 TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
@@ -69,7 +69,7 @@ def _smart_set_backend_and_create_qconfig(cfg, *, is_train):
         backend=backend, is_qat=is_train, use_symmetric=is_symmetric
     )
     if is_train and qat_method == "learnable":
-        qconfig = learnable_qat.convert_to_learnable_qconfig(qconfig)
+        qconfig = convert_to_learnable_qconfig(qconfig)
 
     return qconfig
 

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -28,7 +28,7 @@ from d2go.evaluation.evaluator import inference_on_dataset
 from d2go.modeling import ema, kmeans_anchors
 from d2go.modeling.api import build_d2go_model
 from d2go.modeling.model_freezing_utils import freeze_matched_bn, set_requires_grad
-from d2go.optimizer import build_optimizer_mapper
+from d2go.optimizer.build import build_optimizer_mapper
 from d2go.quantization.modeling import QATHook, setup_qat_model
 from d2go.runner.config_defaults import (
     get_base_runner_default_cfg,

--- a/d2go/runner/lightning_task.py
+++ b/d2go/runner/lightning_task.py
@@ -14,7 +14,7 @@ from d2go.data.datasets import inject_coco_datasets, register_dynamic_datasets
 from d2go.data.utils import update_cfg_if_using_adhoc_dataset
 from d2go.modeling.api import build_meta_arch
 from d2go.modeling.model_freezing_utils import set_requires_grad
-from d2go.optimizer import build_optimizer_mapper
+from d2go.optimizer.build import build_optimizer_mapper
 from d2go.runner.api import RunnerV2Mixin
 from d2go.runner.callbacks.quantization import maybe_prepare_for_quantization, PREPARED
 from d2go.runner.default_runner import (

--- a/d2go/utils/flop_calculator.py
+++ b/d2go/utils/flop_calculator.py
@@ -124,7 +124,9 @@ def add_flop_printing_hook(
 
 @PROFILER_REGISTRY.register()
 def default_flop_counter(model, cfg):
-    from d2go.trainer.fsdp import FSDP
+    from torch.distributed.fsdp.fully_sharded_data_parallel import (
+        FullyShardedDataParallel as FSDP,
+    )
 
     # TODO: deepcopy() not supported for FSDP yet (https://github.com/pytorch/pytorch/issues/82070), so we disable flop counter for now
     if isinstance(model, FSDP):

--- a/tests/modeling/test_optimizer.py
+++ b/tests/modeling/test_optimizer.py
@@ -7,7 +7,7 @@ import unittest
 
 import d2go.runner.default_runner as default_runner
 import torch
-from d2go.optimizer import build_optimizer_mapper
+from d2go.optimizer.build import build_optimizer_mapper
 from d2go.utils.testing import helper
 
 


### PR DESCRIPTION
Summary:
This diff breaks down the TARGETS for dir `quantization`.
Apart from creating the TARGETS the diff temporarily copies the function `_convert_to_d2` from `d2go/runner/lightning_task.py` to avoid circular dependencies. The change is reverted in the diff D46096373.

Reviewed By: tglik

Differential Revision: D45912067

