### PR TITLE
Checkpoint part 1: create a separate buck target

### DIFF
--- a/d2go/data/build.py
+++ b/d2go/data/build.py
@@ -10,7 +10,7 @@ from typing import Dict
 
 import torch
 from d2go.config import CfgNode
-from d2go.data.dataset_mappers import build_dataset_mapper
+from d2go.data.dataset_mappers.build import build_dataset_mapper
 from d2go.data.utils import ClipLengthGroupedDataset
 from detectron2.data import (
     build_batch_data_loader,

--- a/d2go/modeling/subclass.py
+++ b/d2go/modeling/subclass.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List
 import numpy as np
 import torch
 from d2go.config import CfgNode as CN
-from d2go.data.dataset_mappers import D2GO_DATA_MAPPER_REGISTRY, D2GoDatasetMapper
+from d2go.data.dataset_mappers.build import D2GO_DATA_MAPPER_REGISTRY
+from d2go.data.dataset_mappers.d2go_dataset_mapper import D2GoDatasetMapper
 from detectron2.layers import cat
 from detectron2.modeling import ROI_HEADS_REGISTRY, StandardROIHeads
 from detectron2.utils.registry import Registry

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -15,7 +15,7 @@ from d2go.checkpoint import FSDPCheckpointer, is_distributed_checkpoint
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
 from d2go.data.build import build_d2go_train_loader
-from d2go.data.dataset_mappers import build_dataset_mapper
+from d2go.data.dataset_mappers.build import build_dataset_mapper
 from d2go.data.datasets import inject_coco_datasets, register_dynamic_datasets
 from d2go.data.transforms.build import build_transform_gen
 from d2go.data.utils import (

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -11,7 +11,8 @@ from typing import List, Optional, Type, Union
 import d2go.utils.abnormal_checker as abnormal_checker
 import detectron2.utils.comm as comm
 import torch
-from d2go.checkpoint import FSDPCheckpointer, is_distributed_checkpoint
+from d2go.checkpoint.api import is_distributed_checkpoint
+from d2go.checkpoint.fsdp_checkpoint import FSDPCheckpointer
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
 from d2go.data.build import build_d2go_train_loader

--- a/d2go/trainer/fsdp.py
+++ b/d2go/trainer/fsdp.py
@@ -9,7 +9,7 @@ from typing import Callable, Generator, Iterable, Optional
 import torch
 import torch.nn as nn
 from d2go.config import CfgNode as CN
-from d2go.modeling import modeling_hook as mh
+from d2go.modeling.modeling_hook import ModelingHook
 from d2go.registry.builtin import MODELING_HOOK_REGISTRY
 from d2go.trainer.helper import parse_precision_from_string
 from detectron2.utils.registry import Registry
@@ -265,7 +265,7 @@ def build_fsdp(
 
 
 @MODELING_HOOK_REGISTRY.register()
-class FSDPModelingHook(mh.ModelingHook):
+class FSDPModelingHook(ModelingHook):
     """Modeling hook that wraps model in FSDP based on config"""
 
     def apply(self, model: nn.Module) -> FSDPWrapper:


### PR DESCRIPTION
Summary:
The TARGETS for the files inside the directory `checkpoint` are tackled in two parts:

1. This diff creates TARGETS for the files inside `checkpoint` i.e. except `checkpoint/fb/tests`
2. The diff D46096372 creates TARGETS for files inside `checkpoint/fb/tests`

Reviewed By: tglik, wat3rBro

Differential Revision: D45912080

