### PR TITLE
Temp remove output typing for Base Runner create_shared_context

### DIFF
--- a/d2go/data/build.py
+++ b/d2go/data/build.py
@@ -10,7 +10,7 @@ from typing import Dict
 
 import torch
 from d2go.config import CfgNode
-from d2go.data.dataset_mappers import build_dataset_mapper
+from d2go.data.dataset_mappers.build import build_dataset_mapper
 from d2go.data.utils import ClipLengthGroupedDataset
 from detectron2.data import (
     build_batch_data_loader,

--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -37,25 +37,6 @@ logger = logging.getLogger(__name__)
 ModelOutput = Union[None, torch.Tensor, Iterable["ModelOutput"]]
 
 
-def add_distillation_configs(_C: CN) -> None:
-    """Add default parameters to config
-
-    The TEACHER.CONFIG field allows us to build a PyTorch model using an
-    existing config.  We can build any model that is normally supported by
-    D2Go (e.g., FBNet) because we just use the same config
-    """
-    _C.DISTILLATION = CN()
-    _C.DISTILLATION.ALGORITHM = "LabelDistillation"
-    _C.DISTILLATION.HELPER = "BaseDistillationHelper"
-    _C.DISTILLATION.TEACHER = CN()
-    _C.DISTILLATION.TEACHER.TORCHSCRIPT_FNAME = ""
-    _C.DISTILLATION.TEACHER.DEVICE = ""
-    _C.DISTILLATION.TEACHER.TYPE = "torchscript"
-    _C.DISTILLATION.TEACHER.CONFIG_FNAME = ""
-    _C.DISTILLATION.TEACHER.RUNNER_NAME = "d2go.runner.GeneralizedRCNNRunner"
-    _C.DISTILLATION.TEACHER.OVERWRITE_OPTS = []
-
-
 @dataclass
 class LayerLossMetadata:
     loss: nn.Module

--- a/d2go/modeling/subclass.py
+++ b/d2go/modeling/subclass.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List
 import numpy as np
 import torch
 from d2go.config import CfgNode as CN
-from d2go.data.dataset_mappers import D2GO_DATA_MAPPER_REGISTRY, D2GoDatasetMapper
+from d2go.data.dataset_mappers.build import D2GO_DATA_MAPPER_REGISTRY
+from d2go.data.dataset_mappers.d2go_dataset_mapper import D2GoDatasetMapper
 from detectron2.layers import cat
 from detectron2.modeling import ROI_HEADS_REGISTRY, StandardROIHeads
 from detectron2.utils.registry import Registry

--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -10,7 +10,6 @@ from d2go.data.build import (
 from d2go.data.config import add_d2go_data_default_configs
 from d2go.modeling import ema, kmeans_anchors
 from d2go.modeling.backbone.fbnet_cfg import add_fbnet_v2_default_configs
-from d2go.modeling.distillation import add_distillation_configs
 from d2go.modeling.meta_arch.fcos import add_fcos_configs
 from d2go.modeling.model_freezing_utils import add_model_freezing_configs
 from d2go.modeling.subclass import add_subclass_configs
@@ -37,6 +36,25 @@ def _add_detectron2go_runner_default_fb_cfg(_C: CN) -> None:
 @fb_overwritable()
 def _add_base_runner_default_fb_cfg(_C: CN) -> None:
     pass
+
+
+def add_distillation_configs(_C: CN) -> None:
+    """Add default parameters to config
+
+    The TEACHER.CONFIG field allows us to build a PyTorch model using an
+    existing config.  We can build any model that is normally supported by
+    D2Go (e.g., FBNet) because we just use the same config
+    """
+    _C.DISTILLATION = CN()
+    _C.DISTILLATION.ALGORITHM = "LabelDistillation"
+    _C.DISTILLATION.HELPER = "BaseDistillationHelper"
+    _C.DISTILLATION.TEACHER = CN()
+    _C.DISTILLATION.TEACHER.TORCHSCRIPT_FNAME = ""
+    _C.DISTILLATION.TEACHER.DEVICE = ""
+    _C.DISTILLATION.TEACHER.TYPE = "torchscript"
+    _C.DISTILLATION.TEACHER.CONFIG_FNAME = ""
+    _C.DISTILLATION.TEACHER.RUNNER_NAME = "d2go.runner.GeneralizedRCNNRunner"
+    _C.DISTILLATION.TEACHER.OVERWRITE_OPTS = []
 
 
 def _add_detectron2go_runner_default_cfg(_C: CN) -> None:

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -15,7 +15,7 @@ from d2go.checkpoint import FSDPCheckpointer, is_distributed_checkpoint
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
 from d2go.data.build import build_d2go_train_loader
-from d2go.data.dataset_mappers import build_dataset_mapper
+from d2go.data.dataset_mappers.build import build_dataset_mapper
 from d2go.data.datasets import inject_coco_datasets, register_dynamic_datasets
 from d2go.data.transforms.build import build_transform_gen
 from d2go.data.utils import (

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -11,7 +11,8 @@ from typing import List, Optional, Type, Union
 import d2go.utils.abnormal_checker as abnormal_checker
 import detectron2.utils.comm as comm
 import torch
-from d2go.checkpoint import FSDPCheckpointer, is_distributed_checkpoint
+from d2go.checkpoint.api import is_distributed_checkpoint
+from d2go.checkpoint.fsdp_checkpoint import FSDPCheckpointer
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
 from d2go.data.build import build_d2go_train_loader

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -24,7 +24,6 @@ from d2go.data.utils import (
     maybe_subsample_n_images,
     update_cfg_if_using_adhoc_dataset,
 )
-from d2go.distributed import D2GoSharedContext
 from d2go.evaluation.evaluator import inference_on_dataset
 from d2go.modeling import ema, kmeans_anchors
 from d2go.modeling.api import build_d2go_model
@@ -190,7 +189,7 @@ class BaseRunner(object):
         pass
 
     @classmethod
-    def create_shared_context(cls, cfg) -> D2GoSharedContext:
+    def create_shared_context(cls, cfg):
         """
         Override `create_shared_context` in order to run customized code to create distributed shared context that can be accessed by all workers
         """

--- a/d2go/trainer/fsdp.py
+++ b/d2go/trainer/fsdp.py
@@ -9,7 +9,7 @@ from typing import Callable, Generator, Iterable, Optional
 import torch
 import torch.nn as nn
 from d2go.config import CfgNode as CN
-from d2go.modeling import modeling_hook as mh
+from d2go.modeling.modeling_hook import ModelingHook
 from d2go.registry.builtin import MODELING_HOOK_REGISTRY
 from d2go.trainer.helper import parse_precision_from_string
 from detectron2.utils.registry import Registry
@@ -265,7 +265,7 @@ def build_fsdp(
 
 
 @MODELING_HOOK_REGISTRY.register()
-class FSDPModelingHook(mh.ModelingHook):
+class FSDPModelingHook(ModelingHook):
     """Modeling hook that wraps model in FSDP based on config"""
 
     def apply(self, model: nn.Module) -> FSDPWrapper:

--- a/tests/modeling/test_modeling_distillation.py
+++ b/tests/modeling/test_modeling_distillation.py
@@ -13,7 +13,6 @@ from d2go.modeling import modeling_hook as mh
 from d2go.modeling.distillation import (
     _build_teacher,
     _set_device,
-    add_distillation_configs,
     BaseDistillationHelper,
     CachedLayer,
     compute_layer_losses,
@@ -38,6 +37,7 @@ from d2go.registry.builtin import (
     DISTILLATION_HELPER_REGISTRY,
     META_ARCH_REGISTRY,
 )
+from d2go.runner.config_defaults import add_distillation_configs
 from d2go.runner.default_runner import BaseRunner
 from d2go.utils.testing import helper
 from detectron2.checkpoint import DetectionCheckpointer


### PR DESCRIPTION
Summary: Presently, `D2GoSharedContext` is only imported in `mobile-vision/d2go/d2go/runner/default_runner.py` for type annotations. Unfortunately, this causes a circular dependency as the TARGET for `d2go.distributed` does not exists. Remove it temporarily and reintroduce back at the top of the stack once all the TARGETS have been introduced.

Differential Revision: D46096375

