### PR TITLE
Utils part 2: create a separate buck target

### DIFF
--- a/d2go/data/build.py
+++ b/d2go/data/build.py
@@ -10,7 +10,7 @@ from typing import Dict
 
 import torch
 from d2go.config import CfgNode
-from d2go.data.dataset_mappers import build_dataset_mapper
+from d2go.data.dataset_mappers.build import build_dataset_mapper
 from d2go.data.utils import ClipLengthGroupedDataset
 from detectron2.data import (
     build_batch_data_loader,

--- a/d2go/modeling/distillation.py
+++ b/d2go/modeling/distillation.py
@@ -37,25 +37,6 @@ logger = logging.getLogger(__name__)
 ModelOutput = Union[None, torch.Tensor, Iterable["ModelOutput"]]
 
 
-def add_distillation_configs(_C: CN) -> None:
-    """Add default parameters to config
-
-    The TEACHER.CONFIG field allows us to build a PyTorch model using an
-    existing config.  We can build any model that is normally supported by
-    D2Go (e.g., FBNet) because we just use the same config
-    """
-    _C.DISTILLATION = CN()
-    _C.DISTILLATION.ALGORITHM = "LabelDistillation"
-    _C.DISTILLATION.HELPER = "BaseDistillationHelper"
-    _C.DISTILLATION.TEACHER = CN()
-    _C.DISTILLATION.TEACHER.TORCHSCRIPT_FNAME = ""
-    _C.DISTILLATION.TEACHER.DEVICE = ""
-    _C.DISTILLATION.TEACHER.TYPE = "torchscript"
-    _C.DISTILLATION.TEACHER.CONFIG_FNAME = ""
-    _C.DISTILLATION.TEACHER.RUNNER_NAME = "d2go.runner.GeneralizedRCNNRunner"
-    _C.DISTILLATION.TEACHER.OVERWRITE_OPTS = []
-
-
 @dataclass
 class LayerLossMetadata:
     loss: nn.Module

--- a/d2go/modeling/subclass.py
+++ b/d2go/modeling/subclass.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List
 import numpy as np
 import torch
 from d2go.config import CfgNode as CN
-from d2go.data.dataset_mappers import D2GO_DATA_MAPPER_REGISTRY, D2GoDatasetMapper
+from d2go.data.dataset_mappers.build import D2GO_DATA_MAPPER_REGISTRY
+from d2go.data.dataset_mappers.d2go_dataset_mapper import D2GoDatasetMapper
 from detectron2.layers import cat
 from detectron2.modeling import ROI_HEADS_REGISTRY, StandardROIHeads
 from detectron2.utils.registry import Registry

--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -10,7 +10,6 @@ from d2go.data.build import (
 from d2go.data.config import add_d2go_data_default_configs
 from d2go.modeling import ema, kmeans_anchors
 from d2go.modeling.backbone.fbnet_cfg import add_fbnet_v2_default_configs
-from d2go.modeling.distillation import add_distillation_configs
 from d2go.modeling.meta_arch.fcos import add_fcos_configs
 from d2go.modeling.model_freezing_utils import add_model_freezing_configs
 from d2go.modeling.subclass import add_subclass_configs
@@ -37,6 +36,25 @@ def _add_detectron2go_runner_default_fb_cfg(_C: CN) -> None:
 @fb_overwritable()
 def _add_base_runner_default_fb_cfg(_C: CN) -> None:
     pass
+
+
+def add_distillation_configs(_C: CN) -> None:
+    """Add default parameters to config
+
+    The TEACHER.CONFIG field allows us to build a PyTorch model using an
+    existing config.  We can build any model that is normally supported by
+    D2Go (e.g., FBNet) because we just use the same config
+    """
+    _C.DISTILLATION = CN()
+    _C.DISTILLATION.ALGORITHM = "LabelDistillation"
+    _C.DISTILLATION.HELPER = "BaseDistillationHelper"
+    _C.DISTILLATION.TEACHER = CN()
+    _C.DISTILLATION.TEACHER.TORCHSCRIPT_FNAME = ""
+    _C.DISTILLATION.TEACHER.DEVICE = ""
+    _C.DISTILLATION.TEACHER.TYPE = "torchscript"
+    _C.DISTILLATION.TEACHER.CONFIG_FNAME = ""
+    _C.DISTILLATION.TEACHER.RUNNER_NAME = "d2go.runner.GeneralizedRCNNRunner"
+    _C.DISTILLATION.TEACHER.OVERWRITE_OPTS = []
 
 
 def _add_detectron2go_runner_default_cfg(_C: CN) -> None:

--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -8,8 +8,9 @@ from d2go.data.build import (
     add_weighted_training_sampler_default_configs,
 )
 from d2go.data.config import add_d2go_data_default_configs
-from d2go.modeling import ema, kmeans_anchors
 from d2go.modeling.backbone.fbnet_cfg import add_fbnet_v2_default_configs
+from d2go.modeling.ema import add_model_ema_configs
+from d2go.modeling.kmeans_anchors import add_kmeans_anchors_cfg
 from d2go.modeling.meta_arch.fcos import add_fcos_configs
 from d2go.modeling.model_freezing_utils import add_model_freezing_configs
 from d2go.modeling.subclass import add_subclass_configs
@@ -63,13 +64,13 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     # _C.MODEL.FROZEN_LAYER_REG_EXP
     add_model_freezing_configs(_C)
     # _C.MODEL other models
-    ema.add_model_ema_configs(_C)
+    add_model_ema_configs(_C)
     # _C.D2GO_DATA...
     add_d2go_data_default_configs(_C)
     # _C.TENSORBOARD...
     add_tensorboard_default_configs(_C)
     # _C.MODEL.KMEANS...
-    kmeans_anchors.add_kmeans_anchors_cfg(_C)
+    add_kmeans_anchors_cfg(_C)
     # _C.QUANTIZATION
     add_quantization_default_configs(_C)
     # _C.DATASETS.TRAIN_REPEAT_FACTOR

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -15,7 +15,7 @@ from d2go.checkpoint import FSDPCheckpointer, is_distributed_checkpoint
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
 from d2go.data.build import build_d2go_train_loader
-from d2go.data.dataset_mappers import build_dataset_mapper
+from d2go.data.dataset_mappers.build import build_dataset_mapper
 from d2go.data.datasets import inject_coco_datasets, register_dynamic_datasets
 from d2go.data.transforms.build import build_transform_gen
 from d2go.data.utils import (

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -11,7 +11,8 @@ from typing import List, Optional, Type, Union
 import d2go.utils.abnormal_checker as abnormal_checker
 import detectron2.utils.comm as comm
 import torch
-from d2go.checkpoint import FSDPCheckpointer, is_distributed_checkpoint
+from d2go.checkpoint.api import is_distributed_checkpoint
+from d2go.checkpoint.fsdp_checkpoint import FSDPCheckpointer
 from d2go.config import CfgNode, CONFIG_SCALING_METHOD_REGISTRY, temp_defrost
 from d2go.config.utils import get_cfg_diff_table
 from d2go.data.build import build_d2go_train_loader

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -24,7 +24,6 @@ from d2go.data.utils import (
     maybe_subsample_n_images,
     update_cfg_if_using_adhoc_dataset,
 )
-from d2go.distributed import D2GoSharedContext
 from d2go.evaluation.evaluator import inference_on_dataset
 from d2go.modeling import ema, kmeans_anchors
 from d2go.modeling.api import build_d2go_model
@@ -190,7 +189,7 @@ class BaseRunner(object):
         pass
 
     @classmethod
-    def create_shared_context(cls, cfg) -> D2GoSharedContext:
+    def create_shared_context(cls, cfg):
         """
         Override `create_shared_context` in order to run customized code to create distributed shared context that can be accessed by all workers
         """

--- a/d2go/setup.py
+++ b/d2go/setup.py
@@ -23,7 +23,9 @@ from d2go.distributed import (
     get_local_rank,
     get_num_processes_per_machine,
 )
-from d2go.runner import BaseRunner, import_runner, RunnerV2Mixin
+from d2go.runner import import_runner
+from d2go.runner.api import RunnerV2Mixin
+from d2go.runner.default_runner import BaseRunner
 from d2go.runner.lightning_task import DefaultTask
 from d2go.utils.helper import run_once
 from d2go.utils.launch_environment import get_launch_environment

--- a/d2go/trainer/fsdp.py
+++ b/d2go/trainer/fsdp.py
@@ -9,7 +9,7 @@ from typing import Callable, Generator, Iterable, Optional
 import torch
 import torch.nn as nn
 from d2go.config import CfgNode as CN
-from d2go.modeling import modeling_hook as mh
+from d2go.modeling.modeling_hook import ModelingHook
 from d2go.registry.builtin import MODELING_HOOK_REGISTRY
 from d2go.trainer.helper import parse_precision_from_string
 from detectron2.utils.registry import Registry
@@ -265,7 +265,7 @@ def build_fsdp(
 
 
 @MODELING_HOOK_REGISTRY.register()
-class FSDPModelingHook(mh.ModelingHook):
+class FSDPModelingHook(ModelingHook):
     """Modeling hook that wraps model in FSDP based on config"""
 
     def apply(self, model: nn.Module) -> FSDPWrapper:

--- a/d2go/utils/misc.py
+++ b/d2go/utils/misc.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, Iterator, Optional
 
 import detectron2.utils.comm as comm
 import torch
-from d2go.config import CfgNode
+from d2go.config.config import CfgNode
 from d2go.utils.tensorboard_log_util import get_tensorboard_log_dir  # noqa: forwarding
 from detectron2.utils.file_io import PathManager
 from tabulate import tabulate

--- a/d2go/utils/testing/meta_arch_helper.py
+++ b/d2go/utils/testing/meta_arch_helper.py
@@ -3,7 +3,7 @@
 
 
 import torch
-from d2go.quantization.modeling import set_backend_and_create_qconfig
+from d2go.quantization.qconfig import set_backend_and_create_qconfig
 from d2go.registry.builtin import META_ARCH_REGISTRY
 from d2go.utils.testing.data_loader_helper import create_local_dataset
 from detectron2.structures import Boxes, ImageList, Instances

--- a/d2go/utils/testing/rcnn_helper.py
+++ b/d2go/utils/testing/rcnn_helper.py
@@ -10,7 +10,7 @@ from typing import Optional
 import d2go.data.transforms.box_utils as bu
 import torch
 from d2go.export.exporter import convert_and_export_predictor
-from d2go.runner import GeneralizedRCNNRunner
+from d2go.runner.default_runner import GeneralizedRCNNRunner
 from d2go.utils.testing.data_loader_helper import (
     create_detection_data_loader_on_toy_dataset,
 )

--- a/tests/modeling/test_modeling_distillation.py
+++ b/tests/modeling/test_modeling_distillation.py
@@ -13,7 +13,6 @@ from d2go.modeling import modeling_hook as mh
 from d2go.modeling.distillation import (
     _build_teacher,
     _set_device,
-    add_distillation_configs,
     BaseDistillationHelper,
     CachedLayer,
     compute_layer_losses,
@@ -38,6 +37,7 @@ from d2go.registry.builtin import (
     DISTILLATION_HELPER_REGISTRY,
     META_ARCH_REGISTRY,
 )
+from d2go.runner.config_defaults import add_distillation_configs
 from d2go.runner.default_runner import BaseRunner
 from d2go.utils.testing import helper
 from detectron2.checkpoint import DetectionCheckpointer


### PR DESCRIPTION
Summary:
This is the continuation from the part 1 D45912077.
As the dependencies have been resolved, we can define the targets inside the dir `d2go/utils`

Differential Revision: D46096376

