### PR TITLE
fix d2go.config

### DIFF
--- a/d2go/config/__init__.py
+++ b/d2go/config/__init__.py
@@ -9,10 +9,10 @@ from d2go.config.config import (
     CONFIG_CUSTOM_PARSE_REGISTRY,
     CONFIG_SCALING_METHOD_REGISTRY,
     load_full_config_from_file,
-    reroute_config_path,
     temp_defrost,
     temp_new_allowed,
 )
+from d2go.config.utils import reroute_config_path
 
 
 __all__ = [

--- a/d2go/config/config.py
+++ b/d2go/config/config.py
@@ -5,8 +5,8 @@ import contextlib
 import copy
 import logging
 from typing import List
+from unittest import mock
 
-import mock
 import yaml
 from d2go.config.utils import reroute_config_path, resolve_default_config
 from detectron2.config import CfgNode as _CfgNode


### PR DESCRIPTION
Summary:
I think the main issue is that we import `reroute_config_path` from `d2go.config.config` in `__init__.py`, but it's actually in `d2go.config.utils`. After fixing this, the namespace forward also works, see `scripts/wangyanghan/autodeps_testbed/d2go_config/TARGETS`

Update all TARGETS:
```
fbgs -l "d2go/config:" | xargs printf -- '/data/sandcastle/boxes/%s\n' | xargs arc lint -a
```

For reviewers, only `.autodeps.toml` and files in `d2go/d2go/config/` and `scripts/wangyanghan/autodeps_testbed/d2go_config/` are manually changed, other files are auto modified.

Reviewed By: ajinkya-deogade

Differential Revision: D46582416

