### PR TITLE
delete loaded ckpt after use to save memory

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -16,6 +16,7 @@ from d2go.modeling.model_freezing_utils import add_model_freezing_configs
 from d2go.modeling.subclass import add_subclass_configs
 from d2go.quantization.modeling import add_quantization_default_configs
 from d2go.registry.builtin import CONFIG_UPDATER_REGISTRY
+from d2go.trainer.activation_checkpointing import add_activation_checkpoint_configs
 from d2go.trainer.fsdp import add_fsdp_configs
 from d2go.utils.gpu_memory_profiler import add_memory_profiler_configs
 from d2go.utils.visualization import add_tensorboard_default_configs
@@ -87,6 +88,8 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     add_distillation_configs(_C)
     # _C.FSDP
     add_fsdp_configs(_C)
+    # _C.ACTIVATION_CHECKPOINT
+    add_activation_checkpoint_configs(_C)
 
     # Set find_unused_parameters for DistributedDataParallel.
     _C.MODEL.DDP_FIND_UNUSED_PARAMETERS = False

--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -568,6 +568,7 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
             if resume and checkpointer.has_checkpoint()
             else -1
         )
+        del checkpoint
         # The checkpoint stores the training iteration that just finished, thus we start
         # at the next iteration (or iter zero if there's no checkpoint).
         start_iter += 1

--- a/d2go/trainer/activation_checkpointing.py
+++ b/d2go/trainer/activation_checkpointing.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+import logging
+from functools import partial
+
+import torch.nn as nn
+from d2go.config import CfgNode as CN
+from d2go.modeling import modeling_hook as mh
+from d2go.registry.builtin import MODELING_HOOK_REGISTRY
+from d2go.trainer.fsdp import D2GO_FSDP_WRAP_POLICY_REGISTRY
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+    checkpoint_wrapper,
+    CheckpointImpl,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def add_activation_checkpoint_configs(_C: CN):
+    _C.ACTIVATION_CHECKPOINT = CN()
+    _C.ACTIVATION_CHECKPOINT.REENTRANT = False
+    # Find autowrap policy at D2GO_FSDP_WRAP_POLICY_REGISTRY, or use '' to disable autowrap
+    _C.ACTIVATION_CHECKPOINT.AUTO_WRAP_POLICY = "always_wrap_policy"
+    # A list of layer cls names to wrap, case sensitive
+    _C.ACTIVATION_CHECKPOINT.AUTO_WRAP_LAYER_CLS = []
+
+
+def apply_activation_checkpointing_autowrap(
+    model, checkpoint_wrapper_fn, auto_wrap_policy
+):
+    # TODO(@rohan) to be added to torch.distributed.algorithms._checkpoint.checkpoint_wrapper
+    from torch.distributed.fsdp.wrap import _recursive_wrap
+
+    _recursive_wrap(
+        module=model,
+        auto_wrap_policy=auto_wrap_policy,
+        wrapper_cls=checkpoint_wrapper_fn,
+        ignored_modules=set(),
+        ignored_params=set(),
+        only_wrap_children=True,
+    )
+
+
+@MODELING_HOOK_REGISTRY.register()
+class ActivationCheckpointModelingHook(mh.ModelingHook):
+    """Modeling hook that wraps model in activation checkpoint based on config"""
+
+    def apply(self, model: nn.Module) -> nn.Module:
+        logger.info("Activation Checkpointing is used")
+        wrapper_fn = partial(
+            checkpoint_wrapper,
+            checkpoint_impl=CheckpointImpl.NO_REENTRANT
+            if not self.cfg.ACTIVATION_CHECKPOINT.REENTRANT
+            else CheckpointImpl.REENTRANT,
+        )
+        policy_name = self.cfg.ACTIVATION_CHECKPOINT.AUTO_WRAP_POLICY
+        assert (
+            policy_name != "size_based_auto_wrap_policy"
+        ), "ActivationCheckpointing should always be wrapped at module boundary"
+        policy_kwargs = {
+            "layer_names": self.cfg.ACTIVATION_CHECKPOINT.AUTO_WRAP_LAYER_CLS,
+        }
+        auto_wrap_policy = (
+            D2GO_FSDP_WRAP_POLICY_REGISTRY.get(policy_name)(model, **policy_kwargs)
+            if policy_name != ""
+            else lambda _: True
+        )
+
+        apply_activation_checkpointing_autowrap(
+            model, checkpoint_wrapper_fn=wrapper_fn, auto_wrap_policy=auto_wrap_policy
+        )
+        return model
+
+    def unapply(self, model: nn.Module) -> nn.Module:
+        raise NotImplementedError(
+            "ActivationCheckpointModelingHook.unapply() not implemented: can't unwrap an activation checkpoint module"
+        )

--- a/d2go/trainer/helper.py
+++ b/d2go/trainer/helper.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Iterable, List, Union
 
 import torch
 
@@ -19,3 +19,40 @@ def parse_precision_from_string(
         return torch.bfloat16 if not lightning else "bf16"
     else:
         raise ValueError(f"Invalid precision dtype {precision}")
+
+
+def get_module_class_from_name(module, name):
+    """
+    Gets a class from a module by its name. Code borrowed from HuggingFace
+    Args:
+        module (`torch.nn.Module`): The module to get the class from.
+        name (`str`): The name of the class.
+    """
+    modules_children = list(module.children())
+    if module.__class__.__name__ == name:
+        return module.__class__
+    elif len(modules_children) == 0:
+        return
+    else:
+        for child_module in modules_children:
+            module_class = get_module_class_from_name(child_module, name)
+            if module_class is not None:
+                return module_class
+
+
+def get_layer_cls_from_names(
+    model: Any, layer_names: Iterable[str]
+) -> List[torch.nn.Module]:
+    """
+    Get a list of layers from a model that match a list of layer names.
+    """
+    layer_cls = []
+    for name in layer_names:
+        closure = get_module_class_from_name(model, name)
+        if closure is None:
+            raise Exception(
+                f"Could not find the layer class {name} to wrap in the model."
+            )
+        layer_cls.append(closure)
+
+    return layer_cls

--- a/d2go/utils/gpu_memory_profiler.py
+++ b/d2go/utils/gpu_memory_profiler.py
@@ -13,7 +13,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 def add_memory_profiler_configs(_C: CN):
     _C.MEMORY_PROFILER = CN()
-    _C.MEMORY_PROFILER.ENABLED = False
+    _C.MEMORY_PROFILER.ENABLED = True
     # max number of trace entries in memory snapshot
     _C.MEMORY_PROFILER.TRACE_MAX_ENTRIES = 1000000
     # Configs to be used by d2go.utils.gpu_memory_profiler.D2GoGpuMemorySnapshot


### PR DESCRIPTION
Summary:
Currently, d2go runner doesn't delete checkpoint after loading. This is fine if we run `resume=True` because all the model/optimizer/ema state in the checkpoint will be loaded into the corresponding training components. However, in the case of `resume=False`, only model state will be loaded and the optimizer/ema state will be left in memory until the end of training. This could potentially cause OOM if the checkpoint size is large.

This diff deletes loaded ckpt after use to save memory and avoid potentiall OOM issues.

Reviewed By: tglik

Differential Revision: D46674618

