### PR TITLE
remove AC prefix from EMA to make it compatible with loading

### DIFF
--- a/tests/trainer/test_activation_checkpointing.py
+++ b/tests/trainer/test_activation_checkpointing.py
@@ -112,8 +112,6 @@ class TestActivationCheckpointing(unittest.TestCase):
 
     @tempdir
     def test_ac_runner(self, tmp_dir) -> None:
-        tmp_dir = "/tmp/test"
-        os.makedirs(tmp_dir, exist_ok=True)
         ds_name = create_local_dataset(tmp_dir, 5, 10, 10)
         runner = Detectron2GoRunner()
         cfg = _get_cfg(runner, tmp_dir, ds_name)
@@ -124,3 +122,10 @@ class TestActivationCheckpointing(unittest.TestCase):
         model = runner.build_model(cfg)
         runner.do_train(cfg, model, resume=False)
         self.assertTrue(os.path.exists(os.path.join(tmp_dir, "model_0000002.pth")))
+
+        # resume training onto a non-AC-wrapped model
+        cfg.MODEL.MODELING_HOOKS = []
+        cfg.SOLVER.MAX_ITER = 6
+        model = runner.build_model(cfg)
+        runner.do_train(cfg, model, resume=True)
+        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "model_0000005.pth")))


### PR DESCRIPTION
Summary:
# Problem:
d2go EMA uses `named_parameters()` to traverse model states and save EMA checkpoints, while using `state_dict()`  to save model checkpoints. This is a brittle practice because `named_parameters()` and `state_dict()` are calling two sets of python APIs and can return different things.
In the case of Activation Checkpointing (AC), we don't want AC wrapper to affect checkpoint names. Thus, `state_dict()` is overriden by Pytorch to remove prefix "_checkpoint_wrapped_module" from FQN. However, `named_parameters()` does not have that support, so prefix still exists. In the event of us changing AC wrapping strategy (very common for optimization), we will not be able to load the previous EMA state back to the model. And the same problem also happened with FSDP.

# Short-term hack:
This diff adds a short term hack to manually remove the AC prefix in EMA. We can expand `IGNORED_FQN_PREFIX` to support more use cases.

Differential Revision: D46815031

