### PR TITLE
disable FSDP mixed precision for model buffers

### DIFF
--- a/d2go/trainer/fsdp.py
+++ b/d2go/trainer/fsdp.py
@@ -297,7 +297,7 @@ class FSDPModelingHook(ModelingHook):
             use_backward_prefetch=self.cfg.FSDP.BACKWARD_PREFETCH,
             param_dtype=precision_dtype,
             reduce_dtype=precision_dtype,
-            buffer_dtype=precision_dtype,
+            buffer_dtype=None,
             amp_autocast_dtype=precision_dtype,
             use_local_state_dict=self.cfg.FSDP.USE_LOCAL_STATE_DICT,
             load_local_state_dict=self.cfg.FSDP.USE_LOCAL_STATE_DICT,


### PR DESCRIPTION
Summary: Disable FSDP mixed precision for model buffers. Buffers are usually small in size so there's very limited performance gain for enabling mixed precision. Plus, applications like BatchNorm layers and diffusion models are very sensitive to the precision of buffers. Thus, we stick to full precision for buffers in FSDP.

Differential Revision: D46951673

