### PR TITLE
Remove profiling of evaluation

### DIFF
--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -168,11 +168,6 @@ def prepare_fb_model(cfg: CfgNode, model: torch.nn.Module) -> torch.nn.Module:
     return model
 
 
-@fb_overwritable()
-def prepare_fb_model_for_eval(cfg: CfgNode, model: torch.nn.Module) -> torch.nn.Module:
-    return model
-
-
 class BaseRunner(object):
     def __init__(self):
         identifier = f"D2Go.Runner.{self.__class__.__name__}"
@@ -424,8 +419,6 @@ class Detectron2GoRunner(D2GoDataAPIMixIn, BaseRunner):
             )
 
         attach_profilers(cfg, model)
-        if is_final:
-            prepare_fb_model_for_eval(cfg, model)
 
         results = OrderedDict()
         results[model_tag] = OrderedDict()


### PR DESCRIPTION
Summary: Deprecate prepare_fb_model_for_eval().

Reviewed By: miqueljubert

Differential Revision: D47085783

