### PR TITLE
enable autodeps for tests

### DIFF
--- a/tests/data/test_data_transforms.py
+++ b/tests/data/test_data_transforms.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 from d2go.data.transforms.build import build_transform_gen
 from d2go.runner import Detectron2GoRunner
-from detectron2.data.transforms import apply_transform_gens
+from detectron2.data.transforms.augmentation import apply_transform_gens
 
 
 class TestDataTransforms(unittest.TestCase):

--- a/tests/data/test_data_transforms_affine.py
+++ b/tests/data/test_data_transforms_affine.py
@@ -10,7 +10,7 @@ import numpy as np
 import torchvision.transforms as T
 from d2go.data.transforms.build import build_transform_gen
 from d2go.runner import Detectron2GoRunner
-from detectron2.data.transforms import apply_augmentations, AugInput
+from detectron2.data.transforms.augmentation import apply_augmentations, AugInput
 
 
 def generate_test_data(

--- a/tests/data/test_data_transforms_auto_aug.py
+++ b/tests/data/test_data_transforms_auto_aug.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 from d2go.data.transforms.build import build_transform_gen
 from d2go.runner import Detectron2GoRunner
-from detectron2.data.transforms import apply_augmentations
+from detectron2.data.transforms.augmentation import apply_augmentations
 
 
 class TestDataTransformsAutoAug(unittest.TestCase):

--- a/tests/data/test_data_transforms_blur.py
+++ b/tests/data/test_data_transforms_blur.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 from d2go.data.transforms.build import build_transform_gen
 from d2go.runner import Detectron2GoRunner
-from detectron2.data.transforms import apply_augmentations
+from detectron2.data.transforms.augmentation import apply_augmentations
 
 
 class TestDataTransformsBlur(unittest.TestCase):

--- a/tests/data/test_data_transforms_color_yuv.py
+++ b/tests/data/test_data_transforms_color_yuv.py
@@ -8,7 +8,7 @@ import numpy as np
 from d2go.data.transforms import color_yuv as cy
 from d2go.data.transforms.build import build_transform_gen
 from d2go.runner import Detectron2GoRunner
-from detectron2.data.transforms import apply_augmentations
+from detectron2.data.transforms.augmentation import apply_augmentations
 
 
 class TestDataTransformsColorYUV(unittest.TestCase):

--- a/tests/modeling/test_kmeans_anchors.py
+++ b/tests/modeling/test_kmeans_anchors.py
@@ -14,7 +14,7 @@ from d2go.modeling.kmeans_anchors import (
 from d2go.runner import GeneralizedRCNNRunner
 from d2go.utils.testing.data_loader_helper import register_toy_coco_dataset
 from detectron2.data import DatasetCatalog, DatasetFromList, MapDataset
-from detectron2.engine import SimpleTrainer
+from detectron2.engine.train_loop import SimpleTrainer
 from torch.utils.data.sampler import BatchSampler, Sampler
 
 

--- a/tests/modeling/test_modeling_distillation.py
+++ b/tests/modeling/test_modeling_distillation.py
@@ -3,8 +3,8 @@
 
 import unittest
 from typing import List
+from unittest import mock
 
-import mock
 import numpy as np
 import torch
 import torch.nn as nn

--- a/tests/runner/test_runner_lightning_quantization.py
+++ b/tests/runner/test_runner_lightning_quantization.py
@@ -3,8 +3,8 @@
 # pyre-unsafe
 import os
 import unittest
+from unittest import mock
 
-import mock
 import torch
 from d2go.runner.callbacks.quantization import (
     get_default_qat_qconfig,
@@ -20,10 +20,7 @@ from d2go.utils.testing.helper import tempdir
 from d2go.utils.testing.lightning_test_module import TestModule
 from pytorch_lightning import seed_everything, Trainer
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
-from torch.ao.quantization import (  # @manual; @manual
-    default_dynamic_qconfig,
-    get_default_qconfig,
-)
+from torch.ao.quantization.qconfig import default_dynamic_qconfig, get_default_qconfig
 from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
 
 


### PR DESCRIPTION
Summary:
enable autodeps for d2go test to unblock next diff.

maybe in future we can break it into smaller pieces to make tests build and run faster.

Reviewed By: ajinkya-deogade

Differential Revision: D47080563

