### PR TITLE
Fix instrument_checkpoint swallow exception

### DIFF
--- a/d2go/checkpoint/checkpoint_instrumentation.py
+++ b/d2go/checkpoint/checkpoint_instrumentation.py
@@ -33,4 +33,9 @@ class instrument_checkpoint(ContextDecorator):
             unique_id=self.unique_id,
             state="end",
         )
+
+        if exc_value is not None:
+            # Re-raising the exception, otherwise it will be swallowed
+            raise exc_value
+
         return True


### PR DESCRIPTION
Summary: ContextDecorator won't raise exception in `__exit__`. We have to manually re-raise it. Otherwise, the exception will be silently discarded.

Differential Revision: D47454999

