### PR TITLE
Make model_regex_params from qconfig configurable and passable through the json.

### DIFF
--- a/d2go/quantization/modeling.py
+++ b/d2go/quantization/modeling.py
@@ -178,6 +178,7 @@ def add_quantization_default_configs(_C):
     _C.QUANTIZATION.QAT.UPDATE_OBSERVER_STATS_PERIOD = 1
     _C.QUANTIZATION.WEIGHT_OBSERVERS = None
     _C.QUANTIZATION.ACTIVATION_OBSERVERS = None
+    _C.QUANTIZATION.MODEL_NAME_REGEX_PARAMS = None
 
     # post-training quantization
     _C.QUANTIZATION.PTQ = CfgNode()


### PR DESCRIPTION
Summary: Make model_regex_params from qconfig configurable and passable through the json.

Reviewed By: jiaxuzhu92

Differential Revision: D47358394

