### PR TITLE
Add aspect ratio model

### DIFF
--- a/d2go/config/utils.py
+++ b/d2go/config/utils.py
@@ -204,13 +204,12 @@ def get_diff_cfg(old_cfg, new_cfg):
         for key in new_cfg.keys():
             if key not in old_cfg.keys() and old_cfg.is_new_allowed():
                 out[key] = new_cfg[key]
-            elif old_cfg[key] != new_cfg[key]:
+            elif key in old_cfg.keys() and old_cfg[key] != new_cfg[key]:
                 if type(new_cfg[key]) is type(out):
                     out[key] = out.__class__()
                     out[key] = get_diff_cfg_rec(old_cfg[key], new_cfg[key], out[key])
-                else:
-
-                    out[key] = new_cfg[key]
+            else:
+                out[key] = new_cfg[key]
         return out
 
     out = new_cfg.__class__()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/detectron2/pull/5048

Unet support different aspect ratio by natural. For training we need to make change to group images with similar aspect ratio into the same batch and do padding/cropping. For inference, we need to change start_code dimension accordingly.

Here is a result showing 1:1 and 16:9 inference are similar. It supports the mixed training decision. N4024922

Differential Revision: D47682434

