### PR TITLE
Fix empty context manager

### DIFF
--- a/d2go/runner/default_runner.py
+++ b/d2go/runner/default_runner.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
+import contextlib
 import logging
 import os
 from collections import OrderedDict
@@ -170,7 +171,7 @@ def prepare_fb_model(cfg: CfgNode, model: torch.nn.Module) -> torch.nn.Module:
 
 @fb_overwritable()
 def get_monitoring_service() -> Any:
-    pass
+    return contextlib.nullcontext()
 
 
 class BaseRunner(object):


### PR DESCRIPTION
Summary:
In the current form, unit test fails with (https://fburl.com/ssrymti4)
```
 with get_monitoring_service():
E       AttributeError: __enter__
```
Return nullcontext to address.

Differential Revision: D48113440

