### PR TITLE
disable recording memory snapshots after dumping

### DIFF
--- a/d2go/utils/gpu_memory_profiler.py
+++ b/d2go/utils/gpu_memory_profiler.py
@@ -65,6 +65,8 @@ def log_memory_snapshot(output_dir: str, file_prefix: str = "") -> None:
         logger.info(f"Logging memory snapshot to {save_dir}")
         snapshot = torch.cuda.memory._snapshot()
         dump_snapshot(save_dir, snapshot)
+        # disable recording memory history
+        torch.cuda.memory._record_memory_history(enabled=None)
     except Exception as e:
         logger.error(f"Failed to log memory snapshot to {save_dir}: {e}")
 


### PR DESCRIPTION
Summary: Disable recording memory snapshots after dumping to files. Otherwise the process won't have a clean shutdown.

Differential Revision: D48533397

