### PR TITLE
Use the consolidated snapshot API in Unitrace to support Zoomer

### DIFF
--- a/d2go/runner/config_defaults.py
+++ b/d2go/runner/config_defaults.py
@@ -138,10 +138,10 @@ def _add_detectron2go_runner_default_cfg(_C: CN) -> None:
     # Profiler
     _C.PROFILERS = ["default_flop_counter"]
 
-    # GPU memory profiler
+    # Snapshot memory profiling
     add_memory_profiler_configs(_C)
 
-    # Zoomer memory profiling
+    # Zoomer Kineto memory profiling
     add_zoomer_default_config(_C)
 
     # Checkpointing-specific config

--- a/d2go/utils/gpu_memory_profiler.py
+++ b/d2go/utils/gpu_memory_profiler.py
@@ -1,12 +1,6 @@
 import logging
-import os
-import pickle
 
-import torch
 from d2go.config import CfgNode as CN
-from detectron2.utils.file_io import PathManager
-from mobile_cv.torch.utils_pytorch import comm
-from torch.cuda._memory_viz import segment_plot, trace_plot
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -29,84 +23,3 @@ def add_zoomer_default_config(_C: CN):
         False  # Do not enable by default, since it may cause performance regression
     )
     _C.ZOOMER.ENABLE_MEMORY_PROFILING = False
-
-
-def omm_logger_wrapper(output_dir):
-    def oom_logger(
-        device: int, alloc: int, device_alloc: int, device_free: int
-    ) -> None:
-        """
-        Log memory snapshot in the event of CUDA OOM.
-        """
-        logger.info(
-            f"Saving memory snapshot device: {device}, alloc: {alloc}, device_alloc: {device_alloc}, device_free: {device_free}"
-        )
-        try:
-            log_memory_snapshot(output_dir, file_prefix="oom")
-        except Exception as e:
-            logger.error(f"Failed to log memory snapshot during OOM {e}")
-
-    return oom_logger
-
-
-def log_memory_snapshot(output_dir: str, file_prefix: str = "") -> None:
-    """
-    Log memory snapshots to output_dir
-    """
-    if not torch.cuda.is_available():
-        logger.info("CUDA unavailable. Not logging snapshot")
-        return
-
-    try:
-        rank = comm.get_rank()
-        save_dir = os.path.join(
-            output_dir, "memory_snapshot", f"{file_prefix}_rank{rank}"
-        )
-        logger.info(f"Logging memory snapshot to {save_dir}")
-        snapshot = torch.cuda.memory._snapshot()
-        dump_snapshot(save_dir, snapshot)
-    except Exception as e:
-        logger.error(f"Failed to log memory snapshot to {save_dir}: {e}")
-
-
-def dump_snapshot(save_dir: str, snapshot):
-    """
-    Dump memory snapshot and useful plots to save_dir.
-    This is a rewrite of torch.cuda.memory._dump_snapshot() with PathManager.
-    """
-    if not PathManager.exists(save_dir):
-        PathManager.mkdirs(save_dir)
-    with PathManager.open(os.path.join(save_dir, "snapshot.pickle"), "wb") as f:
-        pickle.dump(snapshot, f)
-    with PathManager.open(os.path.join(save_dir, "trace_plot.html"), "w") as f:
-        f.write(trace_plot(snapshot))
-    with PathManager.open(os.path.join(save_dir, "segment_plot.html"), "w") as f:
-        f.write(segment_plot(snapshot))
-    logger.info(f"Saved memory snapshot to {save_dir}")
-
-
-def record_memory_history(trace_max_entries=1000000) -> None:
-    """
-    Start recording memory history and stack traces.
-    """
-    if not torch.cuda.is_available():
-        logger.info("CUDA unavailable. Not recording memory history")
-        return
-
-    torch.cuda.memory._record_memory_history(
-        enabled="all", max_entries=trace_max_entries
-    )
-    logger.info("Started recording memory history")
-
-
-def attach_oom_logger(output_dir, trace_max_entries=1000000) -> None:
-    """
-    Start recording memory history and attach the OOM logger.
-    """
-    if not torch.cuda.is_available():
-        logger.info("CUDA unavailable. Not attaching OOM logger")
-        return
-
-    record_memory_history(trace_max_entries)
-    torch._C._cuda_attach_out_of_memory_observer(omm_logger_wrapper(output_dir))
-    logger.info("Attached GPU OOM logger")


### PR DESCRIPTION
Summary: Similar to D48210543. Update the training_hooks to use the Unitrace memory snapshot APIs. This allows us to maintain a singel path for memory snapshot APIs, and also collect important details such as snapshot location for Zoomer.

Differential Revision: D48368150

