### PR TITLE
Fix cpu().detach() into detach().cpu()

### DIFF
--- a/d2go/utils/visualization.py
+++ b/d2go/utils/visualization.py
@@ -58,7 +58,7 @@ class VisualizerWrapper(object):
         if hasattr(self._get_meta_arch_class(), "visualize_train_input"):
             return self._get_meta_arch_class().visualize_train_input(self, input_dict)
 
-        img = per_image["image"].permute(1, 2, 0).cpu().detach().numpy()
+        img = per_image["image"].permute(1, 2, 0).detach().cpu().numpy()
         img = utils.convert_image_to_rgb(img, cfg.INPUT.FORMAT)
 
         if "dataset_name" in input_dict:


### PR DESCRIPTION
Summary: For visualisation, tensor variables should be detached from the computational graph. The .cpu() function call should be after the detach().

Reviewed By: frabu6

Differential Revision: D48737228

