### PR TITLE
remove logging using logger at exit

### DIFF
--- a/d2go/data/utils.py
+++ b/d2go/data/utils.py
@@ -73,7 +73,6 @@ class AdhocDatasetManager:
     @atexit.register
     def _atexit():
         for ds in AdhocDatasetManager._REGISTERED.values():
-            logger.info("Remove remaining adhoc dataset: {}".format(ds.new_ds_name))
             ds.cleanup()
 
 


### PR DESCRIPTION
Summary: At the exit, file descriptor in the logger for info level logging has already been closed. Calling **logger.info()** will raise an exception. Thus, we remove it.

Reviewed By: ayushidalmia

Differential Revision: D50488097

