### PR TITLE
allow to ignore state dict keys in QAT model

### DIFF
--- a/d2go/export/exporter.py
+++ b/d2go/export/exporter.py
@@ -86,10 +86,12 @@ def _convert_fp_model(
     cfg: CfgNode, pytorch_model: nn.Module, data_loader: Iterable
 ) -> nn.Module:
     """Converts floating point predictor"""
-    pytorch_model = fuse_utils.fuse_model(pytorch_model)
-    logger.info(f"Fused Model:\n{pytorch_model}")
-    if fuse_utils.count_bn_exist(pytorch_model) > 0:
-        logger.warning("BN existed in pytorch model after fusing.")
+    if not isinstance(cfg, CfgNode) or (not cfg.QUANTIZATION.QAT.ENABLED):
+        # Do not fuse model again for QAT model since it will remove observer statistics (e.g. min_val, max_val)
+        pytorch_model = fuse_utils.fuse_model(pytorch_model)
+        logger.info(f"Fused Model:\n{pytorch_model}")
+        if fuse_utils.count_bn_exist(pytorch_model) > 0:
+            logger.warning("BN existed in pytorch model after fusing.")
     return pytorch_model
 
 


### PR DESCRIPTION
Summary:
When we build a QAT model using FX graph mode API **prepare_qat_fx** and **convert_fx**, they will run symbolic tracing following **module.forward()**. 

In certain cases, such as a module takes constant tensor input, the symbolic tracing will add new tensor attributes with name prefix **_tensor_constant** (https://fburl.com/code/msc4ch4o), which becomes new keys in the QAT model state dict.

In current implementation of **_setup_non_qat_to_qat_state_dict_map**, it asserts # of keys in the state dict of original- and QAT model should be the same.

Thus, we extend **qat_state_dict_keys_to_ignore** method by adding an argument, which allows to ignore specified state dict keys in the QAT model.

Differential Revision: D52152706


