### PR TITLE
INPUT.CROP=ENABLED silently fails when annotations dict is present but empty.

### DIFF
--- a/d2go/data/dataset_mappers/d2go_dataset_mapper.py
+++ b/d2go/data/dataset_mappers/d2go_dataset_mapper.py
@@ -94,7 +94,7 @@ class D2GoDatasetMapper(object):
         image, dataset_dict = self._custom_transform(image, dataset_dict)
 
         inputs = AugInput(image=image)
-        if "annotations" not in dataset_dict:
+        if "annotations" not in dataset_dict or dataset_dict["annotations"] == []:
             transforms = AugmentationList(
                 ([self.crop_gen] if self.crop_gen else []) + self.tfm_gens
             )(inputs)


### PR DESCRIPTION
Summary:
D2Go's INPUT.CROP=ENABLED silently fails when annotations dict is present but empty.
Ends up not using the dataset at all.

Adding an additional check to circumvent this failure.

Differential Revision: D55640142


