### PR TITLE
Add new FBNetV3_B_large backbone for HAPTIC.

### DIFF
--- a/d2go/modeling/modeldef/modeldef.py
+++ b/d2go/modeling/modeldef/modeldef.py
@@ -546,6 +546,14 @@ MODEL_ARCH_BUILTIN = {
         "kpts": LARGE_UPSAMPLE_HEAD_D21_STAGES,
         "basic_args": _BASIC_ARGS,
     },
+    "FBNetV3_B_large": {
+        "trunk": FBNetV3_B_no_se[0:4],
+        "rpn": [[_repeat_last(FBNetV3_B_no_se[3])]],
+        "bbox": LARGE_BOX_HEAD_STAGES,
+        "mask": SMALL_DS_UPSAMPLE_HEAD_STAGES,
+        "kpts": LARGE_UPSAMPLE_HEAD_D21_STAGES,
+        "basic_args": _BASIC_ARGS,
+    },
     "FBNetV3_B_light_no_se_C5": {
         "trunk": FBNetV3_B_light_no_se[0:5],
         "rpn": [[_repeat_last(FBNetV3_B_light_no_se[3])]],


### PR DESCRIPTION
Summary: FBNetV3_B_large using FBNetV3_B backbone with large box and kpts heads for better multitask KP+Box detection tasks while being in similar range of #flops and #params.

Differential Revision: D55645349


