### PR TITLE
fix test_integration_tests_coco

### DIFF
--- a/d2go/runner/lightning_task.py
+++ b/d2go/runner/lightning_task.py
@@ -369,6 +369,10 @@ class DefaultTask(D2GoDataAPIMixIn, pl.LightningModule):
             cfg=cfg, dataset_name=dataset_name, output_folder=output_folder
         )
 
+    @classmethod
+    def cleanup(cls) -> None:
+        pass
+
     # ---------------------------------------------------------------------------
     # Hooks
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
> AttributeError: type object 'GeneralizedRCNNTask' has no attribute 'cleanup'

EZ fix

Differential Revision: D60400187
