### PR TITLE
Deterministic D2GO Trainer Params

### DIFF
--- a/tools/lightning_train_net.py
+++ b/tools/lightning_train_net.py
@@ -108,7 +108,11 @@ def get_trainer_params(cfg: CfgNode) -> Dict[str, Any]:
             }
         )
 
-    if hasattr(cfg, "SOLVER.DETERMINISTIC"):
+    if (
+        hasattr(cfg, "SOLVER.DETERMINISTIC")
+        and hasattr(cfg.SOLVER, "DETERMINISTIC")
+        and cfg.SOLVER.DETERMINISTIC
+    ):
         params.update(
             {
                 "sync_batchnorm": True,


### PR DESCRIPTION
Summary:
Previously, cfg.SOLVER.DETERMINISTIC was not taken into account for lightning `Trainer` in d2go:
- Nested checks `hasattr(cfg, "SOLVER.DETERMINISTIC")` do not work as expected
- If SOLVER.DETERMINISTIC exists, we should check that it is set to `True`

Reviewed By: ayushidalmia

Differential Revision: D63426319
